### PR TITLE
movedFileManagerButtonOnIndex

### DIFF
--- a/src/lib/i18n/locales/en.json
+++ b/src/lib/i18n/locales/en.json
@@ -21,11 +21,13 @@
                 "value": "Search By Book",
                 "_context": "Allows the user to search specifically by a 'Book' of the Bible"
             },
-            "a11y": {
-                "settings": {
-                    "value": "Settings",
-                    "_context": "Accessibility settings"
-                }
+            "downloadResourcesForOfflineUse": {
+                "value": "Download resources for offline use",
+                "_context": "Button text telling the user to download resources for offline use"
+            },
+            "youAreCurrentlyOffline": {
+                "value": "You are currently offline. Please connect to the internet to download additional resources.",
+                "_context": "Tooltip text telling the user that they are currently offline"
             }
         },
         "fileManager": {

--- a/src/lib/i18n/locales/tpi.json
+++ b/src/lib/i18n/locales/tpi.json
@@ -16,10 +16,11 @@
             "searchByBook": {
                 "value": "Sospen Long Buk"
             },
-            "a11y": {
-                "settings": {
-                    "value": "Saiting"
-                }
+            "downloadResourcesForOfflineUse": {
+                "value": "Downloadim resos bilong yu long yusim long oflain yusim."
+            },
+            "youAreCurrentlyOffline": {
+                "value": "Yu stap oflain taim nau. Plis konnekim long intanet long downloadim moa resos."
             }
         },
         "fileManager": {

--- a/src/lib/stores/is-online.store.ts
+++ b/src/lib/stores/is-online.store.ts
@@ -1,0 +1,3 @@
+import { writable } from 'svelte/store';
+
+export const isOnline = writable<boolean>(false);


### PR DESCRIPTION
Made use of the svelte special element <svelte:window /> and its ability to bind to window.navigator.onLine. Even though we only use $isOnline on the index page, I figured having $isOnline as a store accessible from everywhere else is pretty handy. The rest of the PR is language translation via chatGPT, svelte conditional templating, and clean up of unused code. 