### PR TITLE
update audio player to work in iOS and Safari

### DIFF
--- a/config/service-worker-pwa.config.ts
+++ b/config/service-worker-pwa.config.ts
@@ -33,7 +33,7 @@ export const serviceWorkerPwaConfig = {
                 options: {
                     cacheName: 'aquifer-api',
                     cacheableResponse: {
-                        statuses: [0, 200],
+                        statuses: [200],
                     },
                 },
             },
@@ -44,7 +44,7 @@ export const serviceWorkerPwaConfig = {
                 options: {
                     cacheName: 'aquifer-cdn',
                     cacheableResponse: {
-                        statuses: [0, 200],
+                        statuses: [200],
                     },
                 },
             },

--- a/src/lib/utils/browser.ts
+++ b/src/lib/utils/browser.ts
@@ -1,7 +1,13 @@
-function isIOSSafari() {
-    return /iP(ad|hone|od).+Version\/[\d.]+.*Safari/i.test(navigator.userAgent);
+// eslint-disable-next-line
+// @ts-nocheck
+
+export function isSafariOnMacOrIOS() {
+    return (
+        !!navigator.userAgent.match(/Version\/[\d.]+.*Safari/) ||
+        (/iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream)
+    );
 }
 
 export function audioFileTypeForBrowser() {
-    return isIOSSafari() ? 'mp3' : 'webm';
+    return isSafariOnMacOrIOS() ? 'mp3' : 'webm';
 }

--- a/src/lib/utils/unzip.ts
+++ b/src/lib/utils/unzip.ts
@@ -10,8 +10,14 @@ export async function readFilesIntoObjectUrlsMapping<T extends ObjectUrlMapping>
     const { entries } = await unzip(zipUrl);
     const fileAndBlob = await asyncMap(Object.entries(entries), async ([key, value]) => [key, await value.blob()]);
     const blobsByFile = Object.fromEntries(fileAndBlob);
-    return mapping.map((map) => ({
-        ...map,
-        url: blobsByFile[map.file] ? URL.createObjectURL(blobsByFile[map.file]) : null,
-    }));
+    return mapping.map((map) => {
+        const fileSplit = map.file.split('.');
+        const extension = fileSplit[fileSplit.length - 1];
+        return {
+            ...map,
+            url: blobsByFile[map.file]
+                ? URL.createObjectURL(new Blob([blobsByFile[map.file]], { type: 'audio/' + extension }))
+                : null,
+        };
+    });
 }


### PR DESCRIPTION
One big thing wrong was the cache wasn't set right for the CDN so the range requests Safari sends
were getting cached and then blowing up when accessing the cache later.

Also when unzipping the files, we needed to make sure the Blob was getting set with the right MIME
type.

Lastly this also fixes some small bugs that were present in the audio player even on Chrome, mostly
around playing multiple clips.
