### PR TITLE
add support for video thumbnails

### DIFF
--- a/src/lib/components/TopNavBar.svelte
+++ b/src/lib/components/TopNavBar.svelte
@@ -67,7 +67,7 @@
     </div>
     <div class="drawer-side">
         <label for="top-navbar-drawer" class="drawer-overlay" />
-        <div class="menu min-h-full w-80 bg-base-200 p-4">
+        <div class="menu min-h-full w-80 bg-base-200 p-4 pb-16">
             <div class="w-100 flex grow flex-col">
                 <div class="flex items-center justify-between">
                     <h3 class="semi-bold text-lg">{$translate('sideMenu.menu.value')}</h3>

--- a/src/lib/data-cache.ts
+++ b/src/lib/data-cache.ts
@@ -13,7 +13,7 @@ export type AllItemsProgress = Record<Url, SingleItemProgress>;
 const _partiallyDownloadedCdnUrls: string[] = [];
 const _partiallyDownloadedApiPaths: string[] = [];
 const cdnRegex =
-    'https://cdn.aquifer.bible.*|https://aquifer-server-(qa|dev|prod).azurewebsites.net/resources/\\d+/content|metadata';
+    'https://cdn.aquifer.bible.*|https://aquifer-server-(qa|dev|prod).azurewebsites.net/resources/\\d+/content|metadata|thumbnail';
 export const staticUrlsMap: StaticUrlsMap = staticUrls;
 
 const fetchFromCacheOrApi = async (path: string) => {

--- a/src/lib/i18n/locales/eng.json
+++ b/src/lib/i18n/locales/eng.json
@@ -68,6 +68,10 @@
                     "value": "See All ({count})",
                     "_context": "Button for the user to see all resources of a given resource type"
                 },
+                "noThumbnail": {
+                    "value": "No thumbnail",
+                    "_context": "Label for videos that have no thumbnail"
+                },
                 "noResourcesFound": {
                     "header": {
                         "value": "No Resources Found",

--- a/src/lib/i18n/locales/hin.json
+++ b/src/lib/i18n/locales/hin.json
@@ -53,6 +53,9 @@
                 "seeAll": {
                     "value": "सब देखें ({count})"
                 },
+                "noThumbnail": {
+                    "value": "कोई थंबनेल नहीं"
+                },
                 "noResourcesFound": {
                     "header": {
                         "value": "कोई संसाधन नहीं मिले"

--- a/src/lib/i18n/locales/tpi.json
+++ b/src/lib/i18n/locales/tpi.json
@@ -53,6 +53,9 @@
                 "seeAll": {
                     "value": "Lukim Olgeta ({count})"
                 },
+                "noThumbnail": {
+                    "value": "Nogat thumbnail"
+                },
                 "noResourcesFound": {
                     "header": {
                         "value": "Nogat Risos i Stap"

--- a/src/lib/service-worker/cacheable-cdn-content-plugin.ts
+++ b/src/lib/service-worker/cacheable-cdn-content-plugin.ts
@@ -6,10 +6,16 @@ class CacheableCdnContentPlugin implements WorkboxPlugin {
         if (response.status === 200) {
             return response;
         } else if (
-            (response.status === 206 || response.status === 0) &&
+            response.status === 0 &&
             (!request.headers.has('Range') || request.headers.get('Range') === 'bytes=0-')
         ) {
             return response;
+        } else if (
+            response.status === 206 &&
+            !response.headers.get('content-encoding') &&
+            (!request.headers.has('Range') || request.headers.get('Range') === 'bytes=0-')
+        ) {
+            return new Response(response.body, { status: 200, headers: response.headers });
         } else {
             return null;
         }

--- a/src/lib/types/resource.ts
+++ b/src/lib/types/resource.ts
@@ -19,7 +19,7 @@ export type MediaTypeEnum = (typeof MediaType)[keyof typeof MediaType];
 
 export interface ResourceContentMetadata {
     displayName: string;
-    metadata: object;
+    metadata: Record<string, unknown>;
 }
 
 export interface ResourceContentTiptap {

--- a/src/lib/utils/data-handlers/resources/resource.ts
+++ b/src/lib/utils/data-handlers/resources/resource.ts
@@ -16,9 +16,18 @@ export function resourceContentApiFullUrl(resourceContent: PassageResourceConten
     return env.PUBLIC_AQUIFER_API_URL + resourceContentApiPath(resourceContent);
 }
 
+function resourceThumbnailApiPath(resourceContent: PassageResourceContent) {
+    return `resources/${resourceContent.contentId}/thumbnail`;
+}
+
+export function resourceThumbnailApiFullUrl(resourceContent: PassageResourceContent) {
+    return env.PUBLIC_AQUIFER_API_URL + resourceThumbnailApiPath(resourceContent);
+}
+
 function resourceMetadataApiPath(resourceContent: PassageResourceContent) {
     return `resources/${resourceContent.contentId}/metadata`;
 }
+
 export function resourceMetadataApiFullPath(resourceContent: PassageResourceContent) {
     return env.PUBLIC_AQUIFER_API_URL + resourceMetadataApiPath(resourceContent);
 }

--- a/src/routes/passage/[passageId]/+page.ts
+++ b/src/routes/passage/[passageId]/+page.ts
@@ -137,8 +137,9 @@ async function getCbbterAudioForPassage(passage: PassageWithResourceContentIds):
         await asyncMap(allAudioResourceContent, async (resourceContent) => {
             try {
                 const metadata = await fetchMetadataForResourceContent(resourceContent);
-                const audioTypeSteps = (metadata?.metadata as CbbtErAudioMetadata | null)?.[audioFileTypeForBrowser()]
-                    .steps;
+                const audioTypeSteps = ((metadata?.metadata || null) as CbbtErAudioMetadata | null)?.[
+                    audioFileTypeForBrowser()
+                ].steps;
                 if (!audioTypeSteps) return null;
                 const steps = (
                     await readFilesIntoObjectUrlsMapping(resourceContentApiFullUrl(resourceContent), audioTypeSteps)

--- a/src/routes/passage/[passageId]/resource-pane/ImageElement.svelte
+++ b/src/routes/passage/[passageId]/resource-pane/ImageElement.svelte
@@ -21,4 +21,5 @@
     class="rounded-lg object-contain"
     src={cachedOrRealUrl(imageState.url ?? '')}
     alt={imageState.displayName}
+    crossorigin="anonymous"
 />

--- a/src/routes/passage/[passageId]/resource-pane/ImageResourceSection.svelte
+++ b/src/routes/passage/[passageId]/resource-pane/ImageResourceSection.svelte
@@ -34,6 +34,7 @@
                     class="mb-1 h-20 w-32 rounded-lg object-cover"
                     src={cachedOrRealUrl(image.url)}
                     alt={image.displayName}
+                    crossorigin="anonymous"
                 />
                 <span class="line-clamp-1 break-all text-sm text-neutral"
                     >{@html htmlWithHighlightedSearchString(image.displayName, searchQuery)}</span

--- a/src/routes/passage/[passageId]/resource-pane/VideoElement.svelte
+++ b/src/routes/passage/[passageId]/resource-pane/VideoElement.svelte
@@ -58,7 +58,6 @@
         const isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
         const isLandscape = window.innerWidth > window.innerHeight;
         isMobileLandscapeMode = isMobile && isLandscape;
-        console.log(isMobileLandscapeMode);
     }
 
     $: isMobileLandscapeMode && makeVideoFullscreen();
@@ -81,6 +80,7 @@
     on:ended={onEnded}
     class="rounded-lg object-contain"
     playsinline
+    crossorigin="anonymous"
 >
     <source src={`${cachedOrRealUrl(videoState.url ?? '')}#t=0.001`} />
 </video>

--- a/src/routes/passage/[passageId]/resource-pane/VideoResourceSection.svelte
+++ b/src/routes/passage/[passageId]/resource-pane/VideoResourceSection.svelte
@@ -9,26 +9,19 @@
     import type { ImageOrVideoResource } from './types';
     import { Icon } from 'svelte-awesome';
     import play from 'svelte-awesome/icons/play';
+    import { _ as translate } from 'svelte-i18n';
 
     export let title: string;
     export let resources: ImageOrVideoResource[];
     export let resourceSelected: (video: ImageOrVideoResource) => void;
     export let searchQuery: string;
 
-    let durations: Record<string, number> = {};
     let carousel: HTMLDivElement | null = null;
 
     $: filteredResources = filterItemsByKeyMatchingSearchQuery(resources, 'displayName', searchQuery);
 
     // if the user clears the search, scroll the carousel back to the left
     $: !shouldSearch(searchQuery) && carousel?.scrollTo({ left: 0, behavior: 'instant' });
-
-    function setVideoDuration(target: EventTarget | null, video: ImageOrVideoResource) {
-        if (target) {
-            const videoElement = target as HTMLVideoElement;
-            durations[video.url] = videoElement.duration;
-        }
-    }
 </script>
 
 {#if resources.length > 0}
@@ -37,28 +30,34 @@
     </div>
     <div bind:this={carousel} class="carousel w-full pb-6 {filteredResources.length > 0 ? 'visible' : 'hidden'}">
         {#each resources as video}
-            {@const duration = durations[video.url]}
             <button
                 class="carousel-item mr-2 w-32 flex-col {filteredResources.includes(video) ? 'visible' : 'hidden'}"
                 on:click={() => resourceSelected(video)}
             >
                 <div class="relative mb-1">
-                    {#if duration}
+                    {#if video.duration}
                         <div
                             class="absolute bottom-1.5 left-1.5 flex flex-row items-center rounded-lg bg-black bg-opacity-80 p-1 pl-2 pr-1.5
-                                text-gray-25"
+                            text-gray-25"
                         >
                             <Icon data={play} scale={0.5} />
-                            <div class="pl-1 text-xs font-semibold">{formatSecondsToMins(duration)}</div>
+                            <div class="pl-1 text-xs font-semibold">{formatSecondsToMins(video.duration)}</div>
                         </div>
                     {/if}
-                    <!-- svelte-ignore a11y-media-has-caption -->
-                    <video
-                        class="h-20 w-32 rounded-lg object-cover"
-                        on:loadedmetadata={({ target }) => setVideoDuration(target, video)}
-                    >
-                        <source src={`${cachedOrRealUrl(video.url)}#t=0.001`} type="video/mp4" />
-                    </video>
+                    {#if video.thumbnailUrl}
+                        <img
+                            class="h-20 w-32 rounded-lg object-cover"
+                            src={cachedOrRealUrl(video.thumbnailUrl)}
+                            alt={video.displayName}
+                            crossorigin="anonymous"
+                        />
+                    {:else}
+                        <div class="h-20 w-32 rounded-lg bg-gray-50">
+                            <div class="mx-auto pt-4 text-sm text-secondary-content">
+                                {$translate('page.passage.resourcePane.noThumbnail.value')}
+                            </div>
+                        </div>
+                    {/if}
                 </div>
                 <span class="line-clamp-1 break-all text-sm text-neutral"
                     >{@html htmlWithHighlightedSearchString(video.displayName, searchQuery)}</span

--- a/src/routes/passage/[passageId]/resource-pane/types.ts
+++ b/src/routes/passage/[passageId]/resource-pane/types.ts
@@ -2,6 +2,8 @@ export interface ImageOrVideoResource {
     type: 'image' | 'video';
     displayName: string | null;
     url: string;
+    duration?: number;
+    thumbnailUrl?: string;
 }
 
 export interface TextResource {

--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -6,6 +6,7 @@ import { NetworkOnly, CacheFirst, CacheOnly } from 'workbox-strategies';
 import { BackgroundSyncPlugin } from 'workbox-background-sync';
 import { createHandlerBoundToURL, cleanupOutdatedCaches, precacheAndRoute } from 'workbox-precaching';
 import { CacheableCdnContentPlugin } from '../src/lib/service-worker/cacheable-cdn-content-plugin';
+import { RangeRequestsPlugin } from 'workbox-range-requests';
 import { CacheFirstAndStaleWhileRevalidateAfterExpiration } from '../src/lib/service-worker/cache-first-and-stale-while-revalidate-after-expiration';
 
 declare let self: ServiceWorkerGlobalScope;
@@ -41,10 +42,10 @@ registerRoute(
 );
 
 registerRoute(
-    /(https:\/\/cdn\.aquifer\.bible.*|https:\/\/aquifer-server-(qa|dev|prod)\.azurewebsites\.net\/resources\/\d+\/(content|metadata))/,
+    /(https:\/\/cdn\.aquifer\.bible.*|https:\/\/aquifer-server-(qa|dev|prod)\.azurewebsites\.net\/resources\/\d+\/(content|metadata|thumbnail))/,
     new CacheFirst({
         cacheName: 'aquifer-cdn',
-        plugins: [new CacheableCdnContentPlugin()],
+        plugins: [new CacheableCdnContentPlugin(), new RangeRequestsPlugin()],
     }),
     'GET'
 );


### PR DESCRIPTION
In order for low-bandwidth clients to not have to load large videos unless they click on them, this adds video thumbnail images.

It also fixes an issue with opaque responses (due to missing crossorigin="anonymous" in the img/video tags) that was resulting in a large amount of cache storage being used. https://developer.chrome.com/docs/devtools/progressive-web-apps/#opaque-responses

Finally it addresses the bottom nav bar covering the side nav bar content when expanded.