### PR TITLE
only show books/chapters in file manager that have CBBT-ER content

### DIFF
--- a/src/lib/components/file-manager/SelectBookMenu.svelte
+++ b/src/lib/components/file-manager/SelectBookMenu.svelte
@@ -6,9 +6,14 @@
     import caretDown from 'svelte-awesome/icons/caretDown';
     import { fetchFromCacheOrApi } from '$lib/data-cache';
     import { addFrontEndDataToBiblesModuleBook } from '$lib/utils/file-manager';
-    import { selectedBookCode, biblesModuleData, biblesModuleBook } from '$lib/stores/file-manager.store';
+    import {
+        selectedBookCode,
+        biblesModuleData,
+        biblesModuleBook,
+        limitChaptersIfNecessary,
+        allowedBooks,
+    } from '$lib/stores/file-manager.store';
 
-    const allowedBooks = ['GEN', 'JOB', 'MAT', 'MRK', 'LUK', 'JHN', 'ACT'];
     let lanaguageMenuDiv: HTMLElement;
     let menuOpen = false;
     let firstBible = $biblesModuleData[0] || { id: null, contents: [] };
@@ -26,6 +31,7 @@
             await fetchFromCacheOrApi(`bibles/${firstBible.id}/book/${bookCode}`)
         );
         $selectedBookCode = bookCode;
+        limitChaptersIfNecessary(bookCode, biblesModuleBook);
     };
 
     const setBookName = (bookCode: string | null) => {

--- a/src/lib/components/file-manager/ViewTable.svelte
+++ b/src/lib/components/file-manager/ViewTable.svelte
@@ -36,7 +36,11 @@
 
         resourcesApiModule.chapters.forEach(async (chapter) => {
             if (chapter.contents.length > 0 && chapter.chapterNumber) {
-                $biblesModuleBook.audioUrls.chapters[chapter.chapterNumber - 1].resourceMenuItems = chapter.contents;
+                const chapterInfoExists = !!$biblesModuleBook.audioUrls.chapters[chapter.chapterNumber - 1];
+                if (chapterInfoExists) {
+                    $biblesModuleBook.audioUrls.chapters[chapter.chapterNumber - 1].resourceMenuItems =
+                        chapter.contents;
+                }
 
                 if (chapter.contents.some((content) => content.typeName === 'CBBTER') && passageData) {
                     let filteredPassages = passageData.find((data) => data.bookCode === $selectedBookCode);
@@ -44,8 +48,9 @@
                     if (filteredPassages) {
                         filteredPassages.passages.forEach((passage) => {
                             if (
-                                chapter.chapterNumber === passage.startChapter ||
-                                chapter.chapterNumber === passage.endChapter
+                                chapterInfoExists &&
+                                (chapter.chapterNumber === passage.startChapter ||
+                                    chapter.chapterNumber === passage.endChapter)
                             ) {
                                 $biblesModuleBook.audioUrls.chapters[
                                     chapter.chapterNumber - 1

--- a/src/lib/stores/file-manager.store.ts
+++ b/src/lib/stores/file-manager.store.ts
@@ -55,3 +55,46 @@ export const downloadData = derived(
         totalSizeToDelete: 0,
     }
 );
+
+const limitChapters = {
+    JOB: ['1', '2'],
+    MAT: [
+        '1',
+        '4',
+        '5',
+        '6',
+        '7',
+        '10',
+        '13',
+        '14',
+        '15',
+        '16',
+        '17',
+        '18',
+        '19',
+        '20',
+        '21',
+        '23',
+        '24',
+        '26',
+        '27',
+        '28',
+    ],
+    LUK: ['1', '2', '3', '4', '5', '6', '7', '8', '16', '17', '18'],
+    JHN: ['4'],
+    ACT: ['7', '8', '9', '10', '11', '12', '13', '14', '17', '18', '19', '20', '21'],
+};
+export const allowedBooks = ['GEN', 'JOB', 'MAT', 'MRK', 'LUK', 'JHN', 'ACT'];
+
+export function limitChaptersIfNecessary(code: string | null, data: typeof biblesModuleBook) {
+    data.update((data) => {
+        data.audioUrls.chapters = data.audioUrls.chapters.filter(({ number }) => {
+            if (code && Object.keys(limitChapters).includes(code)) {
+                const bookCode = code as keyof typeof limitChapters;
+                return limitChapters[bookCode].includes(number);
+            }
+            return true;
+        });
+        return data;
+    });
+}

--- a/src/routes/file-manager/+page.svelte
+++ b/src/routes/file-manager/+page.svelte
@@ -9,6 +9,7 @@
         selectedBookCode,
         biblesModuleData,
         biblesModuleBook,
+        limitChaptersIfNecessary,
     } from '$lib/stores/file-manager.store';
     import { fetchFromCacheOrApi } from '$lib/data-cache';
     import { MetaTags } from 'svelte-meta-tags';
@@ -38,6 +39,7 @@
                     $biblesModuleBook = await addFrontEndDataToBiblesModuleBook(
                         await fetchFromCacheOrApi(`bibles/${firstBible.id}/book/${$selectedBookCode}`)
                     );
+                    limitChaptersIfNecessary($selectedBookCode, biblesModuleBook);
                 }
 
                 $fileManagerLoading = false;


### PR DESCRIPTION
This is a quick and hacky solution to limit the file manager to only show books/chapters with CBBT-ER content. It will be ripped out soon.