### PR TITLE
add about page with licensing info

### DIFF
--- a/src/lib/i18n/locales/eng.json
+++ b/src/lib/i18n/locales/eng.json
@@ -28,6 +28,22 @@
             "loading": {
                 "value": "loading",
                 "_context": "Message to display in the options dropdown when things are loading"
+            },
+            "about": {
+                "value": "About",
+                "_context": "Link to the about page"
+            }
+        },
+        "about": {
+            "error": {
+                "value": "Error loading content license info",
+                "_context": "Message to show when there's an error loading the page for some reason"
+            },
+            "license": {
+                "releasedUnder": {
+                    "value": "Released under a {license}",
+                    "_context": "Description explaining what license the content is released under"
+                }
             }
         },
         "passage": {

--- a/src/lib/i18n/locales/hin.json
+++ b/src/lib/i18n/locales/hin.json
@@ -21,6 +21,19 @@
             },
             "loading": {
                 "value": "लोड हो रहा है"
+            },
+            "about": {
+                "value": "बारे में"
+            }
+        },
+        "about": {
+            "error": {
+                "value": "सामग्री लाइसेंस जानकारी लोड करते समय त्रुटि"
+            },
+            "license": {
+                "releasedUnder": {
+                    "value": "{license} के तहत जारी"
+                }
             }
         },
         "passage": {

--- a/src/lib/i18n/locales/tpi.json
+++ b/src/lib/i18n/locales/tpi.json
@@ -21,6 +21,19 @@
             },
             "loading": {
                 "value": "i laodim"
+            },
+            "about": {
+                "value": "Long em"
+            }
+        },
+        "about": {
+            "error": {
+                "value": "Nogut long karim tok bilong lisens"
+            },
+            "license": {
+                "releasedUnder": {
+                    "value": "I kam aut aninit long wanpela {license}"
+                }
             }
         },
         "passage": {

--- a/src/lib/types/resource.ts
+++ b/src/lib/types/resource.ts
@@ -1,3 +1,5 @@
+import type { LanguageCodeEnum } from '$lib/utils/language-utils';
+
 export const ResourceType = {
     BiblicaBibleDictionary: 'BiblicaBibleDictionary',
     BiblicaStudyNotes: 'BiblicaStudyNotes',
@@ -52,4 +54,17 @@ export interface AudioTypeMetadata {
         file: string;
         stepNumber: number;
     }[];
+}
+
+export interface ApiResourceType {
+    licenseInfo: ApiResourceTypeLicenseInfo | null;
+}
+
+export interface ApiResourceTypeLicenseInfo {
+    title: string;
+    copyright: {
+        dates?: string | null;
+        holder: { name: string; url?: string | null };
+    };
+    license?: Record<LanguageCodeEnum, { name: string; url: string }>;
 }

--- a/src/lib/utils/language-utils.ts
+++ b/src/lib/utils/language-utils.ts
@@ -1,8 +1,12 @@
+export const LanguageCode = { ENG: 'eng', HIN: 'hin', TPI: 'tpi' } as const;
+
+export type LanguageCodeEnum = (typeof LanguageCode)[keyof typeof LanguageCode];
+
 export const supportedLanguages = [
-    { code: 'eng', label: 'English' },
-    { code: 'hin', label: 'हिंदी' },
-    { code: 'tpi', label: 'Tok Pisin' },
-];
+    { code: LanguageCode.ENG, label: 'English' },
+    { code: LanguageCode.HIN, label: 'हिंदी' },
+    { code: LanguageCode.TPI, label: 'Tok Pisin' },
+] as { code: LanguageCodeEnum; label: string }[];
 
 export function browserLanguageToISO6393(browserLanguage: string) {
     const twoDigit = browserLanguage.toLowerCase().split('-')[0];

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,15 +1,11 @@
 <script lang="ts">
     import { _ as translate } from 'svelte-i18n';
-    import { goto } from '$app/navigation';
     import PassageForm from '$lib/components/PassageForm.svelte';
     import { isOnline } from '$lib/stores/is-online.store';
-
-    const goToFileManager = () => {
-        goto('/file-manager');
-    };
 </script>
 
-<section class="container mx-auto flex h-screen">
+<section class="container mx-auto flex h-screen flex-col">
+    <div class="flex-[2]" />
     <div class="flex flex-grow flex-col self-center">
         <div class="mx-auto flex w-full max-w-xs px-6 pb-4">
             <div id="bible-well-logo" class="mr-6 flex h-auto w-16">
@@ -24,10 +20,12 @@
             {$translate('page.index.subTitle.value')}
         </h2>
         <PassageForm />
-        <button class="mx-auto mt-6 max-w-xs text-sky-500" on:click|preventDefault={goToFileManager}
+        <a class="mx-auto mt-6 max-w-xs text-sky-500" href="/file-manager"
             >{$isOnline
                 ? $translate('page.index.downloadResourcesForOfflineUse.value')
-                : $translate('sideMenu.fileManager.value')}</button
+                : $translate('sideMenu.fileManager.value')}</a
         >
     </div>
+    <div class="flex-[1]" />
+    <a class="mx-auto my-6 max-w-xs text-sky-500" href="/about">{$translate('page.index.about.value')}</a>
 </section>

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -1,0 +1,77 @@
+<script lang="ts">
+    import { onMount } from 'svelte';
+    import { _ as translate } from 'svelte-i18n';
+    import { fetchFromCacheOrApi } from '$lib/data-cache';
+    import type { ApiResourceType, ApiResourceTypeLicenseInfo } from '$lib/types/resource';
+    import FullPageSpinner from '$lib/components/FullPageSpinner.svelte';
+    import { Icon } from 'svelte-awesome';
+    import chevronLeft from 'svelte-awesome/icons/chevronLeft';
+    import { goto } from '$app/navigation';
+
+    let resourceLicensesPromise: Promise<ApiResourceTypeLicenseInfo[]> | null = null;
+
+    onMount(() => {
+        resourceLicensesPromise = (fetchFromCacheOrApi('/resources/types') as Promise<ApiResourceType[]>).then(
+            (types) =>
+                (types.map((type) => type.licenseInfo).filter(Boolean) as ApiResourceTypeLicenseInfo[]).sort((a, b) =>
+                    a.title.localeCompare(b.title)
+                )
+        );
+    });
+</script>
+
+<section class="container mx-auto flex h-screen flex-col">
+    <div class="mx-auto flex w-full max-w-[65ch] flex-row items-center py-3">
+        <button class="btn btn-link text-base-500" on:click={() => goto('/')}><Icon data={chevronLeft} /></button>
+        <div class="flex-grow px-3 text-center text-lg font-semibold text-base-content">
+            {$translate('page.index.about.value')}
+        </div>
+        <!-- hack to make text centered -->
+        <div class="btn btn-link text-base-500 opacity-0"><Icon data={chevronLeft} /></div>
+    </div>
+    {#await resourceLicensesPromise}
+        <FullPageSpinner />
+    {:then resourceLicenses}
+        <div class="flex flex-col self-center px-4">
+            <div class="prose my-6">
+                {#if resourceLicenses}
+                    {#each resourceLicenses as license}
+                        <h4>{license.title}</h4>
+                        <div class="ml-4">
+                            <div>
+                                © {license.copyright.dates ?? ''}
+                                {#if license.copyright.holder.url}
+                                    <a class="text-sky-500" href={license.copyright.holder.url}
+                                        >{license.copyright.holder.name}</a
+                                    >
+                                {:else}
+                                    {license.copyright.holder.name}
+                                {/if}
+                            </div>
+                            {#if license.license?.eng}
+                                <div>
+                                    {@html $translate('page.about.license.releasedUnder.value', {
+                                        values: {
+                                            license: license.license.eng.url
+                                                ? `<a class="text-sky-500"
+                                    href="${license.license.eng.url}">${license.license.eng.name}</a>`
+                                                : license.license.eng.name,
+                                        },
+                                    })}
+                                </div>
+                            {/if}
+                        </div>
+                    {/each}
+                {:else}
+                    {$translate('page.about.error.value')}
+                {/if}
+            </div>
+        </div>
+    {:catch}
+        <div class="flex flex-col self-center px-4">
+            <div class="prose my-6">
+                {$translate('page.about.error.value')}
+            </div>
+        </div>
+    {/await}
+</section>

--- a/src/routes/passage/[passageId]/resource-pane/FullscreenMediaResource.svelte
+++ b/src/routes/passage/[passageId]/resource-pane/FullscreenMediaResource.svelte
@@ -168,7 +168,7 @@
                 {/if}
                 <button
                     disabled={currentIndex === 0}
-                    class="btn btn-link text-gray-50 disabled:bg-opacity-0 disabled:text-gray-50 disabled:text-opacity-25"
+                    class="btn btn-link text-gray-50 disabled:bg-opacity-0 disabled:text-transparent disabled:text-opacity-25"
                     on:click={previousItem}><Icon data={chevronLeft} /></button
                 >
                 {#if videoState.active && !videoState.isLoading}
@@ -182,7 +182,7 @@
                 {/if}
                 <button
                     disabled={currentIndex === resources.length - 1}
-                    class="btn btn-link text-gray-50 disabled:bg-opacity-0 disabled:text-gray-50
+                    class="btn btn-link text-gray-50 disabled:bg-opacity-0 disabled:text-transparent
                     disabled:text-opacity-25"
                     on:click={nextItem}><Icon data={chevronRight} /></button
                 >


### PR DESCRIPTION
This gets things setup to display license info/content attribution on the /about page.

The format expected in the LicenseInfo DB column is:
```
{
    "title": "Church-Based Bible Translation - Enhanced Resources",
    "copyright": {
        "dates": "2023",
        "holder": {
            "name": "SRV Partners",
            "url": "https://srvpartners.org/home/"
        }
    },
    "license": {
        "eng": {
            "name": "CC BY-SA 4.0 license",
            "url": "https://creativecommons.org/licenses/by-sa/4.0/legalcode.en"
        }
    }
}
```

It shows up in the UI like:
<img width="264" alt="Screenshot at Oct 24 12-35-26" src="https://github.com/BiblioNexusStudio/well-web/assets/4652012/00cf0604-b810-4fa4-bb7a-340b27ff0160">
<img width="265" alt="Screenshot at Oct 24 12-38-42" src="https://github.com/BiblioNexusStudio/well-web/assets/4652012/0db7b415-1288-4fb4-af69-c3b96e8bb6dc">
