### PR TITLE
pull bible licenses alongside resource licenses

### DIFF
--- a/src/lib/types/bible-text-content.ts
+++ b/src/lib/types/bible-text-content.ts
@@ -1,4 +1,5 @@
 import type { FrontendAudioChapter } from './file-manager';
+import type { ApiLicenseInfo } from './resource';
 
 export interface BibleBookTextContent {
     chapters: BibleBookTextChapter[];
@@ -18,6 +19,7 @@ export interface BaseBible {
     abbreviation: string;
     id: number;
     name: string;
+    licenseInfo: ApiLicenseInfo | null;
 }
 
 export interface ApiBible extends BaseBible {

--- a/src/lib/types/resource.ts
+++ b/src/lib/types/resource.ts
@@ -57,10 +57,10 @@ export interface AudioTypeMetadata {
 }
 
 export interface ApiResourceType {
-    licenseInfo: ApiResourceTypeLicenseInfo | null;
+    licenseInfo: ApiLicenseInfo | null;
 }
 
-export interface ApiResourceTypeLicenseInfo {
+export interface ApiLicenseInfo {
     title: string;
     copyright: {
         dates?: string | null;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -33,7 +33,7 @@
     }
 
     async function precacheNecessaryCalls() {
-        await fetchFromCacheOrApi('/resources/types');
+        await Promise.all([fetchFromCacheOrApi('/resources/types'), fetchFromCacheOrApi('/bibles')]);
     }
 
     onMount(() => {


### PR DESCRIPTION
This adds to the existing about page to show Bible licenses alongside the other resource licenses we were already showing.