### PR TITLE
improve CBBT-ER step button carousel and fix dropdown issues

### DIFF
--- a/src/lib/components/ButtonCarousel.svelte
+++ b/src/lib/components/ButtonCarousel.svelte
@@ -15,12 +15,25 @@
         const targetElement = buttonElements[index];
 
         if (carousel && targetElement) {
-            const offset = targetElement.offsetLeft - carousel.offsetLeft;
+            const nextElement = buttonElements[index + 1];
+
+            let offset;
+            if (nextElement) {
+                const nextOffset = nextElement.offsetLeft - carousel.offsetLeft;
+                offset = nextOffset + nextElement.offsetWidth - carousel.offsetWidth;
+            } else {
+                offset = carousel.scrollWidth - carousel.offsetWidth;
+            }
+
             carousel.scrollTo({ left: offset, behavior: 'smooth' });
         }
     }
 
     onMount(() => {
+        if (carousel) {
+            // reset the scroll to prevent browsers from saving it
+            carousel.scrollTo({ left: 0, behavior: 'instant' });
+        }
         if (scroll && carousel) {
             carousel.scrollTo({ left: scroll, behavior: 'instant' });
         }

--- a/src/lib/components/TopNavBar.svelte
+++ b/src/lib/components/TopNavBar.svelte
@@ -37,7 +37,7 @@
     <input id="top-navbar-drawer" type="checkbox" class="drawer-toggle" bind:checked={$isSideMenuOpen} />
     <div class="drawer-content flex flex-col">
         <div class="navbar w-full">
-            <div class="semi-bold flex-1 px-2 text-lg">{title}</div>
+            <div class="semi-bold line-clamp-1 flex-1 break-all px-2 text-lg">{title}</div>
             {#if passage && $featureFlags.audioRecording}
                 <div class="flex-none">
                     <details class="dropdown dropdown-end">

--- a/src/lib/components/file-manager/LanguageMenu.svelte
+++ b/src/lib/components/file-manager/LanguageMenu.svelte
@@ -6,7 +6,7 @@
     import caretDown from 'svelte-awesome/icons/caretDown';
     import { onMount } from 'svelte';
 
-    let lanaguageMenuDiv: HTMLElement;
+    let languageMenuDiv: HTMLElement;
     let menuOpen = false;
 
     $: currentLanguage = supportedLanguages.find((language) => language.code === $currentLanguageCode);
@@ -17,11 +17,12 @@
 
     const onLanguageSelected = (lanaguageCode: string) => {
         $currentLanguageCode = lanaguageCode;
+        toggleMenu();
     };
 
     onMount(() => {
         const handleClickOutside = (event: MouseEvent) => {
-            if (lanaguageMenuDiv && !lanaguageMenuDiv.contains(event.target as Node) && menuOpen) {
+            if (languageMenuDiv && !languageMenuDiv.contains(event.target as Node) && menuOpen) {
                 toggleMenu();
             }
         };
@@ -34,16 +35,19 @@
     });
 </script>
 
-<div class="relative flex h-full w-1/2 items-center pl-2" bind:this={lanaguageMenuDiv}>
+<div class="relative ml-2 flex h-full w-1/2 items-center" bind:this={languageMenuDiv}>
     <button class="btn btn-primary btn-outline flex w-full justify-between" on:click={toggleMenu}>
         {currentLanguage?.label} ({$currentLanguageCode}) <Icon data={menuOpen ? caretUp : caretDown} />
     </button>
     {#if menuOpen}
-        <div class="border-2-primary menu absolute right-0 top-16 z-30 space-y-8 rounded-md bg-white p-4 shadow-lg">
+        <div
+            class="menu absolute right-0 top-16 z-30 space-y-8 rounded-md border-2 border-primary-300 bg-white p-4 shadow-lg"
+            style="width: {languageMenuDiv.clientWidth}px;"
+        >
             {#each supportedLanguages as lanaguage}
                 <button
                     type="button"
-                    class="ml-8 flex justify-start text-primary"
+                    class="flex justify-start text-primary"
                     on:click={() => onLanguageSelected(lanaguage.code)}
                     aria-label={lanaguage.label}
                 >
@@ -53,10 +57,3 @@
         </div>
     {/if}
 </div>
-
-<style>
-    .menu {
-        width: calc(100vw - 2rem);
-        border: 2px solid #80d4f3;
-    }
-</style>

--- a/src/lib/components/file-manager/ResourceMenu.svelte
+++ b/src/lib/components/file-manager/ResourceMenu.svelte
@@ -93,14 +93,17 @@
     });
 </script>
 
-<div class="relative flex h-full w-1/2 items-center pr-2" bind:this={resourcesMenuDiv}>
+<div class="relative mr-2 flex h-full w-1/2 items-center" bind:this={resourcesMenuDiv}>
     <button class="btn btn-primary btn-outline flex w-full justify-between" on:click={toggleMenu}>
         {$translate('page.fileManager.viewRow.resources.value')} ({selectedResources.length}) <Icon
             data={menuOpen ? caretUp : caretDown}
         />
     </button>
     {#if menuOpen}
-        <div class="border-2-primary menu absolute left-0 top-16 z-30 rounded-md bg-white shadow-lg">
+        <div
+            class="menu absolute left-0 top-16 z-30 rounded-md border-2 border-primary-300 bg-white shadow-lg"
+            style="width: {resourcesMenuDiv.clientWidth}px;"
+        >
             {#each $resourcesMenu as resource}
                 {#if resource.display}
                     <label class="label mb-4 cursor-pointer justify-start">
@@ -112,10 +115,3 @@
         </div>
     {/if}
 </div>
-
-<style>
-    .menu {
-        width: calc(100vw - 2rem);
-        border: 2px solid #80d4f3;
-    }
-</style>

--- a/src/lib/components/file-manager/SelectBookMenu.svelte
+++ b/src/lib/components/file-manager/SelectBookMenu.svelte
@@ -14,7 +14,7 @@
         allowedBooks,
     } from '$lib/stores/file-manager.store';
 
-    let lanaguageMenuDiv: HTMLElement;
+    let bookMenuDiv: HTMLElement;
     let menuOpen = false;
     let firstBible = $biblesModuleData[0] || { id: null, contents: [] };
 
@@ -41,7 +41,7 @@
 
     onMount(() => {
         const handleClickOutside = (event: MouseEvent) => {
-            if (lanaguageMenuDiv && !lanaguageMenuDiv.contains(event.target as Node) && menuOpen) {
+            if (bookMenuDiv && !bookMenuDiv.contains(event.target as Node) && menuOpen) {
                 toggleMenu();
             }
         };
@@ -54,7 +54,7 @@
     });
 </script>
 
-<div class="relative flex h-full w-full items-center" bind:this={lanaguageMenuDiv}>
+<div class="relative flex h-full w-full items-center" bind:this={bookMenuDiv}>
     <button
         class="btn btn-primary btn-outline flex w-full justify-between"
         on:click={toggleMenu}
@@ -65,13 +65,13 @@
     </button>
     {#if menuOpen}
         <div
-            class="border-2-primary menu absolute left-0 top-16 z-30 flex flex-col flex-nowrap space-y-8 overflow-y-scroll rounded-md bg-white p-4 shadow-lg"
-            style="height: min(66vh, calc({books.length * 3.25}rem + 4px))"
+            class="menu absolute left-0 top-16 z-30 flex flex-col flex-nowrap space-y-8 overflow-y-scroll rounded-md border-2 border-primary-300 bg-white p-4 shadow-lg"
+            style="height: min(66vh, calc({books.length * 3.25}rem + 4px)); width: {bookMenuDiv.clientWidth}px;"
         >
             {#each books as book}
                 <button
                     type="button"
-                    class="ml-8 flex justify-start text-primary"
+                    class="flex justify-start text-primary"
                     aria-label={book.displayName}
                     on:click={() => handleBookClick(book.bookCode)}
                 >
@@ -81,10 +81,3 @@
         </div>
     {/if}
 </div>
-
-<style>
-    .menu {
-        width: calc(100vw - 2rem);
-        border: 2px solid #80d4f3;
-    }
-</style>


### PR DESCRIPTION
In order to make it easier for people to switch steps on desktop (and mobile to a lesser extent),
this improves the auto-scroll behavior of the button carousel. Now it will always scroll into view
the button to the right of the current step.

Also addresses some small things related to dropdowns.