### PR TITLE
make sure service worker updates on page refresh

### DIFF
--- a/config/service-worker-pwa.config.ts
+++ b/config/service-worker-pwa.config.ts
@@ -9,6 +9,7 @@ export const serviceWorkerPwaConfig = {
     registerType: 'prompt',
     injectRegister: null,
     devOptions: { enabled: true, type: 'module', suppressWarnings: true },
+    base: '/',
     injectManifest: {
         globPatterns: ['client/**/*.{html,js,css,ico,png,svg,webp,webmanifest}'],
         globIgnores: ['**/*.webmanifest'],

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -24,7 +24,9 @@
                 // we know that the page must have just been refreshed, and we can go ahead and do the
                 // service worker update without fear of disturbing the user
                 if (Date.now() - initializedAt < 1500) {
-                    updateServiceWorker();
+                    // The timeout is here to make the browser happy. For some reason if immediately fired, the new service
+                    // worker won't be activated.
+                    setTimeout(updateServiceWorker, 750);
                 }
             },
         });


### PR DESCRIPTION
This fixes two issues:
1) Because `base` wasn't set, the service worker was being requested from every nested path instead of only the root one (e.g. `/`, `/passage`, etc) and resulting in unnecessary HTTP requests
2) The `updateServiceWorker` call was happening immediately, which for some reason the browser doesn't like. By delaying it by 750ms, we ensure the update happens consistently.