### PR TITLE
Another fix for passage selector problems

### DIFF
--- a/src/lib/components/PassageForm.svelte
+++ b/src/lib/components/PassageForm.svelte
@@ -17,6 +17,7 @@
 
     let onLanguageSelected = (event: Event) => {
         const { value } = event.target as HTMLSelectElement;
+        $selectedBookIndex = 'default';
         $currentLanguageCode = value;
     };
 
@@ -25,7 +26,6 @@
 
     async function callFetchData(isOnline = true) {
         isLoading = true;
-        $selectedBookIndex = 'default';
         await fetchCbbterPassagesByBook(isOnline);
         isLoading = false;
     }


### PR DESCRIPTION
Move setting selectedBookIndex back to default to the onLanguageSelected call. Appears to fix the original problem without breaking the persistence.