### PR TITLE
capitalizedPassageValue

### DIFF
--- a/src/lib/i18n/locales/tpi.json
+++ b/src/lib/i18n/locales/tpi.json
@@ -8,7 +8,7 @@
                 "value": "Buk"
             },
             "passage": {
-                "value": "hap riding"
+                "value": "Hap Riding"
             },
             "go": {
                 "value": "Go"


### PR DESCRIPTION
The translator did not capitalize where needed. This is a correction.