### PR TITLE
rename resource type to parent resource

### DIFF
--- a/src/lib/components/file-manager/ResourceMenu.svelte
+++ b/src/lib/components/file-manager/ResourceMenu.svelte
@@ -13,7 +13,7 @@
     import { fetchFromCacheOrApi } from '$lib/data-cache';
     import { currentLanguageInfo } from '$lib/stores/current-language.store';
     import type { ResourcesMenuItem } from '$lib/types/file-manager';
-    import { ResourceType } from '$lib/types/resource';
+    import { ParentResourceName } from '$lib/types/resource';
     import { addFrontEndDataToResourcesMenuItems } from '$lib/utils/file-manager';
 
     let resourcesMenuDiv: HTMLElement;
@@ -31,7 +31,7 @@
             const queryParams = resourcesMenu
                 .map((resource) => {
                     if (resource.selected && !resource.isBible) {
-                        return `resourceTypes=${resource.value}`;
+                        return `parentResourceNames=${resource.value}`;
                     } else {
                         return '';
                     }
@@ -51,35 +51,35 @@
             ...$bibleDataForResourcesMenu,
             {
                 name: $translate('resources.types.CBBTER.value'),
-                value: ResourceType.CBBTER,
+                value: ParentResourceName.CBBTER,
                 selected: true,
                 isBible: false,
                 display: true,
             },
             {
                 name: $translate('resources.types.tyndaleBibleDictionary.value'),
-                value: ResourceType.TyndaleBibleDictionary,
+                value: ParentResourceName.TyndaleBibleDictionary,
                 selected: false,
                 isBible: false,
                 display: true,
             },
             {
                 name: $translate('resources.types.tyndaleStudyNotes.value'),
-                value: ResourceType.TyndaleStudyNotes,
+                value: ParentResourceName.TyndaleStudyNotes,
                 selected: false,
                 isBible: false,
                 display: true,
             },
             {
                 name: $translate('resources.types.ubsImages.value'),
-                value: ResourceType.UbsImages,
+                value: ParentResourceName.UbsImages,
                 selected: false,
                 isBible: false,
                 display: true,
             },
             {
                 name: $translate('resources.types.videoBibleDictionary.value'),
-                value: ResourceType.VideoBibleDictionary,
+                value: ParentResourceName.VideoBibleDictionary,
                 selected: false,
                 isBible: false,
                 display: true,
@@ -116,7 +116,7 @@
                     <label class="label mb-4 cursor-pointer justify-start">
                         <input
                             type="checkbox"
-                            disabled={resource.value === ResourceType.CBBTER}
+                            disabled={resource.value === ParentResourceName.CBBTER}
                             bind:checked={resource.selected}
                             class="checkbox-primary checkbox"
                         />

--- a/src/lib/components/file-manager/ViewTable.svelte
+++ b/src/lib/components/file-manager/ViewTable.svelte
@@ -19,7 +19,7 @@
     import { METADATA_ONLY_FAKE_FILE_SIZE, fetchFromCacheOrApi } from '$lib/data-cache';
     import { currentLanguageInfo } from '$lib/stores/current-language.store';
     import { passageContentApiFullPath } from '$lib/utils/data-handlers/resources/passages';
-    import { MediaType } from '$lib/types/resource';
+    import { MediaType, ParentResourceName } from '$lib/types/resource';
     import Image from '$lib/icons/Image.svelte';
     import ImageAndVideo from '$lib/icons/ImageAndVideo.svelte';
     import Video from '$lib/icons/Video.svelte';
@@ -36,8 +36,10 @@
     async function addAdditaonalResourcesApiModule(resourcesApiModule: ResourcesApiModule) {
         let passageData: BasePassagesByBook[] = [];
 
-        if ($resourcesMenu.some((resource) => resource.selected && resource.value === 'CBBTER')) {
-            passageData = await fetchFromCacheOrApi(`passages/language/${$currentLanguageInfo?.id}/resource/CBBTER`);
+        if ($resourcesMenu.some((resource) => resource.selected && resource.value === ParentResourceName.CBBTER)) {
+            passageData = await fetchFromCacheOrApi(
+                `passages/language/${$currentLanguageInfo?.id}/resource/${ParentResourceName.CBBTER}`
+            );
         }
 
         resourcesApiModule.chapters.forEach(async (chapter) => {
@@ -48,7 +50,10 @@
                         chapter.contents;
                 }
 
-                if (chapter.contents.some((content) => content.typeName === 'CBBTER') && passageData) {
+                if (
+                    chapter.contents.some((content) => content.parentResourceName === ParentResourceName.CBBTER) &&
+                    passageData
+                ) {
                     let filteredPassages = passageData.find((data) => data.bookCode === $selectedBookCode);
 
                     if (filteredPassages) {

--- a/src/lib/types/file-manager.ts
+++ b/src/lib/types/file-manager.ts
@@ -178,7 +178,7 @@ export interface BiblesModuleBook {
 
 export interface CbbterTextContent {
     contentId: number;
-    typeName: string;
+    parentResourceName: string;
     mediaTypeName: string;
     contentSize: number;
 }

--- a/src/lib/types/passage.ts
+++ b/src/lib/types/passage.ts
@@ -17,7 +17,7 @@ export interface PassageResourceContent {
     contentId: number;
     contentSize: number;
     mediaTypeName: MediaTypeEnum;
-    typeName: string;
+    parentResourceName: string;
 }
 
 export interface FrontendPassageResourceContent extends PassageResourceContent {

--- a/src/lib/types/resource.ts
+++ b/src/lib/types/resource.ts
@@ -1,6 +1,6 @@
 import type { LanguageCodeEnum } from '$lib/utils/language-utils';
 
-export const ResourceType = {
+export const ParentResourceName = {
     BiblicaBibleDictionary: 'BiblicaBibleDictionary',
     BiblicaStudyNotes: 'BiblicaStudyNotes',
     CBBTER: 'CBBTER',
@@ -10,7 +10,7 @@ export const ResourceType = {
     VideoBibleDictionary: 'VideoBibleDictionary',
 } as const;
 
-export type ResourceTypeEnum = (typeof ResourceType)[keyof typeof ResourceType];
+export type ParentResourceNameEnum = (typeof ParentResourceName)[keyof typeof ParentResourceName];
 
 export const MediaType = {
     Text: 'Text',
@@ -56,7 +56,7 @@ export interface AudioTypeMetadata {
     }[];
 }
 
-export interface ApiResourceType {
+export interface ApiParentResource {
     licenseInfo: ApiLicenseInfo | null;
 }
 

--- a/src/lib/utils/data-handlers/resources/passages.ts
+++ b/src/lib/utils/data-handlers/resources/passages.ts
@@ -11,7 +11,7 @@ import type {
     PassageWithResourceContentIds,
     BasePassage,
 } from '$lib/types/passage';
-import { ResourceType } from '$lib/types/resource';
+import { ParentResourceName } from '$lib/types/resource';
 import { resourceContentApiFullUrl } from './resource';
 
 async function getBibleBookCodesToName(languageId: number | null = null) {
@@ -35,7 +35,7 @@ async function passageIdHasCbbterAvailable(passageId: number, isOnline: boolean)
             `passages/${passageId}/language/${get(currentLanguageInfo)?.id}`
         )) as PassageWithResourceContentIds;
         const cbbterResources = passageWithContentIds.contents.filter(
-            ({ typeName }) => typeName === ResourceType.CBBTER
+            ({ parentResourceName }) => parentResourceName === ParentResourceName.CBBTER
         );
         return await asyncSome(cbbterResources, async (resourceContent) => {
             return isCachedFromCdn(resourceContentApiFullUrl(resourceContent));

--- a/src/lib/utils/file-manager.ts
+++ b/src/lib/utils/file-manager.ts
@@ -14,7 +14,7 @@ import {
     resourceMetadataApiFullPath,
     resourceThumbnailApiFullUrl,
 } from '$lib/utils/data-handlers/resources/resource';
-import { MediaType } from '$lib/types/resource';
+import { MediaType, ParentResourceName } from '$lib/types/resource';
 
 export const convertToReadableSize = (size: number) => {
     const kb = 1024;
@@ -86,7 +86,7 @@ export const calculateUrlsWithMetadataToChange = (
                         if (resourceMenuItem.mediaTypeName === MediaType.Text) {
                             if (
                                 resourcesMenu.some(
-                                    ({ selected, value }) => selected && value === resourceMenuItem.typeName
+                                    ({ selected, value }) => selected && value === resourceMenuItem.parentResourceName
                                 )
                             ) {
                                 urlsAndSizesToDownload.push({
@@ -110,7 +110,7 @@ export const calculateUrlsWithMetadataToChange = (
                         if (resourceMenuItem.mediaTypeName === MediaType.Audio) {
                             if (
                                 resourcesMenu.some(
-                                    ({ selected, value }) => selected && value === resourceMenuItem.typeName
+                                    ({ selected, value }) => selected && value === resourceMenuItem.parentResourceName
                                 )
                             ) {
                                 urlsAndSizesToDownload.push({
@@ -179,7 +179,7 @@ export const calculateUrlsWithMetadataToChange = (
         }
     });
 
-    if (resourcesMenu.some(({ selected, value }) => selected && value === 'CBBTER')) {
+    if (resourcesMenu.some(({ selected, value }) => selected && value === ParentResourceName.CBBTER)) {
         biblesModuleBook.audioUrls.chapters.forEach((chapter) => {
             if (chapter.cbbterResourceUrls?.length && chapter.cbbterResourceUrls?.length > 0) {
                 chapter.cbbterResourceUrls.forEach((cbbterResourceUrl) => {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -18,7 +18,7 @@
     }
 
     async function precacheNecessaryCalls() {
-        await Promise.all([fetchFromCacheOrApi('/resources/types'), fetchFromCacheOrApi('/bibles')]);
+        await Promise.all([fetchFromCacheOrApi('/resources/parent-resources'), fetchFromCacheOrApi('/bibles')]);
     }
 
     onMount(() => {

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -2,7 +2,7 @@
     import { onMount } from 'svelte';
     import { _ as translate } from 'svelte-i18n';
     import { fetchFromCacheOrApi } from '$lib/data-cache';
-    import type { ApiResourceType, ApiLicenseInfo } from '$lib/types/resource';
+    import type { ApiParentResource, ApiLicenseInfo } from '$lib/types/resource';
     import FullPageSpinner from '$lib/components/FullPageSpinner.svelte';
     import { Icon } from 'svelte-awesome';
     import chevronLeft from 'svelte-awesome/icons/chevronLeft';
@@ -46,7 +46,7 @@
 
     async function fetchLicenses() {
         const [resourceLicenses, bibleLicenses] = await Promise.all([
-            fetchFromCacheOrApi('/resources/types') as Promise<ApiResourceType[]>,
+            fetchFromCacheOrApi('/resources/parent-resources') as Promise<ApiParentResource[]>,
             fetchFromCacheOrApi('/bibles') as Promise<BaseBible[]>,
         ]);
         const licenses = resourceLicenses

--- a/src/routes/passage/[passageId]/data-fetchers.ts
+++ b/src/routes/passage/[passageId]/data-fetchers.ts
@@ -15,7 +15,7 @@ import { fetchAllBibles, bookDataForBibleTab } from '$lib/utils/data-handlers/bi
 import { range } from '$lib/utils/array';
 import { parseTiptapJsonToHtml } from '$lib/utils/tiptap-parsers';
 import type { BasePassage, PassageResourceContent, PassageWithResourceContentIds } from '$lib/types/passage';
-import { MediaType, ResourceType, type CbbtErAudioMetadata, type CbbtErAudioContent } from '$lib/types/resource';
+import { MediaType, ParentResourceName, type CbbtErAudioMetadata, type CbbtErAudioContent } from '$lib/types/resource';
 import {
     fetchDisplayNameForResourceContent,
     fetchMetadataForResourceContent,
@@ -114,7 +114,8 @@ export async function fetchBibleContent(passage: BasePassage, bible: FrontendBib
 
 async function getCbbterAudioForPassage(passage: PassageWithResourceContentIds): Promise<CbbtErAudioContent[]> {
     const allAudioResourceContent = passage.contents.filter(
-        ({ mediaTypeName, typeName }) => typeName === ResourceType.CBBTER && mediaTypeName === MediaType.Audio
+        ({ mediaTypeName, parentResourceName }) =>
+            parentResourceName === ParentResourceName.CBBTER && mediaTypeName === MediaType.Audio
     );
     return (
         await asyncMap(allAudioResourceContent, async (resourceContent) => {
@@ -139,7 +140,8 @@ async function getCbbterAudioForPassage(passage: PassageWithResourceContentIds):
 
 async function getCbbterTextForPassage(passage: PassageWithResourceContentIds): Promise<CbbtErTextContent[]> {
     const allTextResourceContent = passage.contents.filter(
-        ({ mediaTypeName, typeName }) => typeName === ResourceType.CBBTER && mediaTypeName === MediaType.Text
+        ({ mediaTypeName, parentResourceName }) =>
+            parentResourceName === ParentResourceName.CBBTER && mediaTypeName === MediaType.Text
     );
     return (
         await asyncMap(allTextResourceContent, async (resourceContent) => {
@@ -164,7 +166,9 @@ async function getCbbterTextForPassage(passage: PassageWithResourceContentIds): 
 async function getAdditionalResourcesForPassage(
     passage: PassageWithResourceContentIds
 ): Promise<PassageResourceContent[]> {
-    const additionalResourceContent = passage.contents.filter(({ typeName }) => typeName !== ResourceType.CBBTER);
+    const additionalResourceContent = passage.contents.filter(
+        ({ parentResourceName }) => parentResourceName !== ParentResourceName.CBBTER
+    );
     return await asyncFilter(
         additionalResourceContent,
         async (resourceContent) => get(isOnline) || (await isCachedFromCdn(resourceContentApiFullUrl(resourceContent)))

--- a/src/routes/passage/[passageId]/resource-pane/FullscreenTextResourceSection.svelte
+++ b/src/routes/passage/[passageId]/resource-pane/FullscreenTextResourceSection.svelte
@@ -2,23 +2,24 @@
     import { trapFocus } from '$lib/utils/trap-focus';
     import type { TextResource } from './types';
     import TextResourceSection from './TextResourceSection.svelte';
-    import type { ResourceTypeEnum } from '$lib/types/resource';
+    import type { ParentResourceNameEnum } from '$lib/types/resource';
 
-    export let type: ResourceTypeEnum | null;
-    export let textResourcesByType: Record<ResourceTypeEnum, TextResource[]>;
+    export let parentResourceName: ParentResourceNameEnum | null;
+    export let textResourcesByParentResource: Record<ParentResourceNameEnum, TextResource[]>;
     export let resourceSelected: (resource: TextResource) => void;
-    export let showTypeFullscreen: ((type: ResourceTypeEnum | null) => void) | null = null;
+    export let showParentResourceFullscreen: ((parentResourceName: ParentResourceNameEnum | null) => void) | null =
+        null;
 
     let searchQuery = '';
 </script>
 
-{#if type}
+{#if parentResourceName}
     <div use:trapFocus class="fixed inset-0 z-[45] flex w-full flex-col bg-primary-content px-4">
         <TextResourceSection
-            {type}
-            resources={textResourcesByType[type]}
+            {parentResourceName}
+            resources={textResourcesByParentResource[parentResourceName]}
             bind:searchQuery
-            {showTypeFullscreen}
+            {showParentResourceFullscreen}
             {resourceSelected}
             isFullscreen={true}
         />

--- a/src/routes/passage/[passageId]/resource-pane/TextResourceSection.svelte
+++ b/src/routes/passage/[passageId]/resource-pane/TextResourceSection.svelte
@@ -10,32 +10,33 @@
     import { _ as translate } from 'svelte-i18n';
     import chevronLeft from 'svelte-awesome/icons/chevronLeft';
     import SearchInput from '$lib/components/SearchInput.svelte';
-    import { ResourceType, type ResourceTypeEnum } from '$lib/types/resource';
+    import { ParentResourceName, type ParentResourceNameEnum } from '$lib/types/resource';
     import NoResourcesFound from './NoResourcesFound.svelte';
 
-    export let type: ResourceTypeEnum;
+    export let parentResourceName: ParentResourceNameEnum;
     export let resources: TextResource[];
     export let resourceSelected: (resource: TextResource) => void;
     export let searchQuery: string;
     export let isFullscreen: boolean;
-    export let showTypeFullscreen: ((type: ResourceTypeEnum | null) => void) | null = null;
+    export let showParentResourceFullscreen: ((parentResourceName: ParentResourceNameEnum | null) => void) | null =
+        null;
 
-    function calculateTitle(type: ResourceTypeEnum) {
-        switch (type) {
-            case ResourceType.TyndaleBibleDictionary:
+    function calculateTitle(parentResourceName: ParentResourceNameEnum) {
+        switch (parentResourceName) {
+            case ParentResourceName.TyndaleBibleDictionary:
                 return $translate('resources.types.tyndaleBibleDictionary.value');
-            case ResourceType.TyndaleStudyNotes:
+            case ParentResourceName.TyndaleStudyNotes:
                 return $translate('resources.types.tyndaleStudyNotes.value');
-            case ResourceType.BiblicaBibleDictionary:
+            case ParentResourceName.BiblicaBibleDictionary:
                 return $translate('resources.types.biblicaBibleDictionary.value');
-            case ResourceType.BiblicaStudyNotes:
+            case ParentResourceName.BiblicaStudyNotes:
                 return $translate('resources.types.biblicaStudyNotes.value');
             default:
                 return null;
         }
     }
 
-    $: title = calculateTitle(type);
+    $: title = calculateTitle(parentResourceName);
 
     // resources filtered to:
     // - searched results if searching OR
@@ -52,7 +53,7 @@
     {#if isFullscreen}
         <div class="mx-auto w-full max-w-[65ch]">
             <div class="flex w-full flex-row items-center py-3">
-                <button class="btn btn-link text-base-500" on:click={() => showTypeFullscreen?.(null)}
+                <button class="btn btn-link text-base-500" on:click={() => showParentResourceFullscreen?.(null)}
                     ><Icon data={chevronLeft} /></button
                 >
                 <div class="flex-grow px-3 text-center text-lg font-semibold text-base-content">{title}</div>
@@ -75,7 +76,9 @@
             <div class="text-md font-semibold text-base-content">{title}</div>
             <div class="flex-grow"></div>
             {#if !shouldSearch(searchQuery) && resources.length > 5}
-                <button class="text-sm font-semibold text-base-500" on:click={() => showTypeFullscreen?.(type)}
+                <button
+                    class="text-sm font-semibold text-base-500"
+                    on:click={() => showParentResourceFullscreen?.(parentResourceName)}
                     >{$translate('page.passage.resourcePane.seeAll.value', {
                         values: { count: resources.length },
                     })}</button

--- a/src/routes/passage/[passageId]/resource-pane/types.ts
+++ b/src/routes/passage/[passageId]/resource-pane/types.ts
@@ -1,4 +1,4 @@
-import type { ResourceTypeEnum } from '$lib/types/resource';
+import type { ParentResourceNameEnum } from '$lib/types/resource';
 
 export interface ImageOrVideoResource {
     type: 'image' | 'video';
@@ -12,5 +12,5 @@ export interface TextResource {
     displayName: string | null;
     html: string;
     preview: string;
-    typeName: ResourceTypeEnum;
+    parentResourceName: ParentResourceNameEnum;
 }


### PR DESCRIPTION
To be compatible with the rename of ResourceType to ParentResource in Aquifer, this updates all the
places that were referencing `ResourceType` or `typeName` or `types` to reference the new names.
