### PR TITLE
don't log unsupported browser errors to app insights

### DIFF
--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,5 +1,6 @@
 import { ApplicationInsights } from '@microsoft/applicationinsights-web';
 import config from '$lib/config';
+import { browserSupported } from './utils/browser';
 
 const appInsights = new ApplicationInsights({
     config: {
@@ -20,8 +21,11 @@ const additionalProperties = {
 
 export const log = {
     exception: (error: Error | undefined) => {
-        // Distinguish between network errors (which can't be avoided) and other errors we may want to look into
         if (error && error.name === 'TypeError' && error.message === 'Failed to fetch') {
+            // Don't log network errors to app insights (since they can't be avoided)
+            console.error(error);
+        } else if (!browserSupported) {
+            // Don't log errors of unsupported browsers to app insights (since they can't be avoided)
             console.error(error);
         } else if (error) {
             appInsights.trackException({ exception: error }, additionalProperties);

--- a/src/lib/utils/browser.ts
+++ b/src/lib/utils/browser.ts
@@ -1,6 +1,8 @@
 // eslint-disable-next-line
 // @ts-nocheck
 
+import { browser } from '$app/environment';
+
 export function isSafariOnMacOrIOS() {
     return (
         !!navigator.userAgent.match(/Version\/[\d.]+.*Safari/) ||
@@ -11,3 +13,5 @@ export function isSafariOnMacOrIOS() {
 export function audioFileTypeForBrowser() {
     return isSafariOnMacOrIOS() ? 'mp3' : 'webm';
 }
+
+export const browserSupported = browser && 'serviceWorker' in navigator;

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -9,6 +9,7 @@ import { currentLanguageCode } from '$lib/stores/current-language.store';
 // @ts-ignore
 import { registerSW } from 'virtual:pwa-register';
 import { log } from '$lib/logger';
+import { browserSupported } from '$lib/utils/browser';
 
 export const ssr = false;
 
@@ -28,7 +29,7 @@ export const load: LayoutLoad = async () => {
             },
         });
 
-        if ('serviceWorker' in navigator) {
+        if (browserSupported) {
             const registration = await navigator.serviceWorker.getRegistration();
 
             // There's an active SW, but no controller for this tab.
@@ -46,9 +47,9 @@ export const load: LayoutLoad = async () => {
         const fetchedLanguages = await fetchFromCacheOrApi(`languages/`);
         languages.set(fetchedLanguages);
 
-        return { browserSupported: 'serviceWorker' in navigator, error: false };
+        return { browserSupported, error: false };
     } catch (error) {
         log.exception(error as Error);
-        return { browserSupported: 'serviceWorker' in navigator, error: true };
+        return { browserSupported, error: true };
     }
 };


### PR DESCRIPTION
Since unsupported browsers cause 401 errors (due to not having a service worker that can inject the API key onto requests), we were getting false positives in app insights. This prevents us from logging errors to app insights if we know the browser is not supported anyway.