### PR TITLE
fix undefined error and add stricter TS settings to catch future issues

### DIFF
--- a/src/lib/components/DebugModal.svelte
+++ b/src/lib/components/DebugModal.svelte
@@ -20,8 +20,8 @@
     const boxSize = 0.2; // 20% of screen width/height
 
     function handleTap(e: TouchEvent) {
-        const x = e.changedTouches[0].clientX;
-        const y = e.changedTouches[0].clientY;
+        const x = e.changedTouches[0]?.clientX ?? 0;
+        const y = e.changedTouches[0]?.clientY ?? 0;
         const width = window.innerWidth;
         const height = window.innerHeight;
 

--- a/src/lib/components/file-manager/FmModal.svelte
+++ b/src/lib/components/file-manager/FmModal.svelte
@@ -32,7 +32,7 @@
             ],
             [0, 0]
         );
-        const downloadFinished = objectKeys(progress).every((key: string) => progress[key].done);
+        const downloadFinished = objectKeys(progress).every((key: string) => progress[key]!.done);
 
         if (downloadFinished) {
             downloadInProgress = false;

--- a/src/lib/components/file-manager/SelectBookMenu.svelte
+++ b/src/lib/components/file-manager/SelectBookMenu.svelte
@@ -16,7 +16,7 @@
 
     let bookMenuDiv: HTMLElement;
     let menuOpen = false;
-    let firstBible = $biblesModuleData[0] || { id: null, contents: [] };
+    let firstBible = $biblesModuleData[0] || { id: null, contents: [], books: [] };
 
     $: books = firstBible.books.filter((book) => allowedBooks.includes(book.bookCode));
     $: bookName = setBookName($selectedBookCode);

--- a/src/lib/components/file-manager/ViewTable.svelte
+++ b/src/lib/components/file-manager/ViewTable.svelte
@@ -46,8 +46,10 @@
             if (chapter.contents.length > 0 && chapter.chapterNumber) {
                 const chapterInfoExists = !!$biblesModuleBook.audioUrls.chapters[chapter.chapterNumber - 1];
                 if (chapterInfoExists) {
-                    $biblesModuleBook.audioUrls.chapters[chapter.chapterNumber - 1].resourceMenuItems =
-                        chapter.contents;
+                    const chapterObject = $biblesModuleBook.audioUrls.chapters[chapter.chapterNumber - 1];
+                    if (chapterObject) {
+                        chapterObject.resourceMenuItems = chapter.contents;
+                    }
                 }
 
                 if (
@@ -65,7 +67,7 @@
                             ) {
                                 $biblesModuleBook.audioUrls.chapters[
                                     chapter.chapterNumber - 1
-                                ].cbbterResourceUrls?.push({
+                                ]?.cbbterResourceUrls?.push({
                                     url: passageContentApiFullPath(passage),
                                     mediaType: MediaType.Text,
                                     metadataOnly: true,

--- a/src/lib/data-cache.ts
+++ b/src/lib/data-cache.ts
@@ -160,14 +160,19 @@ export async function cacheManyFromCdnWithProgress(
     progressCallback(progress);
 
     const updateProgress = (url: Url, downloadedSize: number, totalSize: number, done: boolean) => {
-        progress[url] = {
-            downloadedSize:
-                progress[url].metadataOnly && done
-                    ? Math.min(METADATA_ONLY_FAKE_FILE_SIZE, downloadedSize)
-                    : downloadedSize,
-            totalSize: progress[url].metadataOnly ? METADATA_ONLY_FAKE_FILE_SIZE : totalSize || progress[url].totalSize,
-            done,
-        };
+        const currentProgress = progress[url];
+        if (currentProgress) {
+            progress[url] = {
+                downloadedSize:
+                    currentProgress.metadataOnly && done
+                        ? Math.min(METADATA_ONLY_FAKE_FILE_SIZE, downloadedSize)
+                        : downloadedSize,
+                totalSize: currentProgress.metadataOnly
+                    ? METADATA_ONLY_FAKE_FILE_SIZE
+                    : totalSize || currentProgress.totalSize,
+                done,
+            };
+        }
         progressCallback(progress);
     };
 

--- a/src/lib/utils/async-array.ts
+++ b/src/lib/utils/async-array.ts
@@ -42,7 +42,7 @@ export async function asyncReduce<T, R>(
 ): Promise<R> {
     let acc = initialValue;
     for (let i = 0; i < array.length; i++) {
-        acc = await reducer(acc, array[i], i, array);
+        acc = await reducer(acc, array[i]!, i, array);
     }
     return acc;
 }

--- a/src/lib/utils/data-handlers/resources/resource.ts
+++ b/src/lib/utils/data-handlers/resources/resource.ts
@@ -40,7 +40,7 @@ export async function fetchTiptapForResourceContent(
         const tiptaps = (await fetchFromCacheOrCdn(resourceContentApiFullUrl(resourceContent))) as
             | ResourceContentTiptap[]
             | null;
-        return tiptaps?.length ? tiptaps[0] : null;
+        return tiptaps?.[0] ?? null;
     } catch (error) {
         // tiptap data not cached
         log.exception(error as Error);
@@ -71,8 +71,8 @@ export function resourceDisplayNameSorter(a: { displayName: string | null }, b: 
     const aMatch = a.displayName?.match(passageRegex);
     const bMatch = b.displayName?.match(passageRegex);
     if (aMatch && bMatch) {
-        const aId = parseInt(aMatch[1]) * 1000000 + parseInt(aMatch[2]) * 1000 + parseInt(aMatch[3] ?? '0');
-        const bId = parseInt(bMatch[1]) * 1000000 + parseInt(bMatch[2]) * 1000 + parseInt(bMatch[3] ?? '0');
+        const aId = parseInt(aMatch[1]!) * 1000000 + parseInt(aMatch[2]!) * 1000 + parseInt(aMatch[3] ?? '0');
+        const bId = parseInt(bMatch[1]!) * 1000000 + parseInt(bMatch[2]!) * 1000 + parseInt(bMatch[3] ?? '0');
         return aId - bId;
     } else if (a.displayName && b.displayName) {
         return a.displayName.localeCompare(b.displayName);

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -21,7 +21,7 @@
             return null;
         }
         if (licenses.length === 1) {
-            const license = licenses[0];
+            const license = licenses[0]!;
             return $translate('page.about.license.releasedUnderSingle.value', {
                 values: {
                     name: license.url

--- a/src/routes/passage/[passageId]/+page.svelte
+++ b/src/routes/passage/[passageId]/+page.svelte
@@ -80,7 +80,7 @@
         bibleData = null;
         multiClipAudioStates = {};
         baseFetchPromise = (async () => {
-            passage = await fetchPassage($page.params.passageId);
+            passage = await fetchPassage($page.params.passageId!);
         })();
     }
 
@@ -109,7 +109,7 @@
         }));
         bibleData = newBibleData;
         if (!selectedBibleId || !bibleData?.biblesForTabs.map(({ id }) => id).includes(selectedBibleId)) {
-            selectedBibleId = bibleData?.biblesForTabs?.[0].id ?? null;
+            selectedBibleId = bibleData?.biblesForTabs?.[0]?.id ?? null;
         }
         await fetchContentForBibleId(selectedBibleId);
         await cacheNonSelectedBiblesIfOnline();
@@ -117,22 +117,22 @@
 
     async function fetchContentForBibleId(id: number | null) {
         const index = bibleData?.biblesForTabs.findIndex((bible) => bible.id === id) ?? -1;
-        if (bibleData && index >= 0) {
-            bibleData.biblesForTabs[index].loadingContent = true;
+        if (bibleData && bibleData.biblesForTabs[index]) {
+            bibleData.biblesForTabs[index]!.loadingContent = true;
             const bibleBook = bibleData.biblesForTabs[index];
             if (bibleBook && passage) {
                 if (!bibleBook.content) {
                     const content = await fetchBibleContent(passage, bibleBook);
                     // make sure the index hasn't changed
-                    if (bibleData.biblesForTabs[index].id === id) {
-                        bibleData.biblesForTabs[index].content = content;
+                    if (bibleData.biblesForTabs[index]!.id === id) {
+                        bibleData.biblesForTabs[index]!.content = content;
                         populateBibleAudioState();
                     }
                 }
             }
-            const currentIndex = bibleData?.biblesForTabs.findIndex((bible) => bible.id === id) ?? -1;
-            if (currentIndex >= 0) {
-                bibleData.biblesForTabs[currentIndex].loadingContent = false;
+            const currentIndex = bibleData.biblesForTabs.findIndex((bible) => bible.id === id) ?? -1;
+            if (currentIndex >= 0 && bibleData?.biblesForTabs[currentIndex]) {
+                bibleData.biblesForTabs[currentIndex]!.loadingContent = false;
             }
         }
     }
@@ -304,7 +304,7 @@
                             bind:scroll={cbbterSelectedStepScroll}
                             buttons={stepsAvailable.map((stepNumber) => ({
                                 value: stepNumber,
-                                label: steps[stepNumber - 1],
+                                label: steps[stepNumber - 1] ?? '',
                             }))}
                         />
                     </div>

--- a/src/routes/passage/[passageId]/data-fetchers.ts
+++ b/src/routes/passage/[passageId]/data-fetchers.ts
@@ -58,17 +58,17 @@ export async function fetchBibleContent(passage: BasePassage, bible: FrontendBib
                             chapterNumber === passage.startChapter
                                 ? audioUrlData.audioTimestamps.find(
                                       ({ verseNumber }: AudioTimestamp) =>
-                                          passage.startVerse === parseInt(verseNumber.split('-')[0])
+                                          passage.startVerse === parseInt(verseNumber.split('-')[0]!)
                                   )?.start
-                                : audioUrlData.audioTimestamps[0].start;
+                                : audioUrlData.audioTimestamps[0]?.start;
 
                         const endTimestamp =
                             chapterNumber === passage.endChapter
                                 ? audioUrlData.audioTimestamps.find(
                                       ({ verseNumber }: AudioTimestamp) =>
-                                          passage.endVerse === parseInt(verseNumber.split('-')[0])
+                                          passage.endVerse === parseInt(verseNumber.split('-')[0]!)
                                   )?.end
-                                : audioUrlData.audioTimestamps[audioUrlData.audioTimestamps.length - 1].end;
+                                : audioUrlData.audioTimestamps[audioUrlData.audioTimestamps.length - 1]?.end;
 
                         audioData = {
                             url,
@@ -93,7 +93,7 @@ export async function fetchBibleContent(passage: BasePassage, bible: FrontendBib
                         audioData,
                         versesText:
                             chapterText?.verses.filter((verse) => {
-                                const verseNumber = parseInt(verse.number.split('-')[0]);
+                                const verseNumber = parseInt(verse.number.split('-')[0]!);
                                 return (
                                     (chapterNumber > passage.startChapter ||
                                         (chapterNumber === passage.startChapter &&

--- a/src/routes/passage/[passageId]/resource-pane/FullscreenMediaResource.svelte
+++ b/src/routes/passage/[passageId]/resource-pane/FullscreenMediaResource.svelte
@@ -79,7 +79,7 @@
     $: [videoElement, sliderElement, imageElement] && setVideoOrImageDimensionsBasedOnAvailableHeight();
 
     let currentResource: ImageOrVideoResource | null = null;
-    $: currentResource = currentIndex === null ? null : resources[currentIndex];
+    $: currentResource = currentIndex === null ? null : resources[currentIndex] ?? null;
 
     // when the index changes, reset the current state and setup the new one
     $: setupImageOrVideoState(currentIndex);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
         "checkJs": true,
         "esModuleInterop": true,
         "forceConsistentCasingInFileNames": true,
+        "noUncheckedIndexedAccess": true,
         "resolveJsonModule": true,
         "skipLibCheck": true,
         "sourceMap": true,


### PR DESCRIPTION
We were missing some optional chaining code in a spot that was causing silent errors for end users when loading content in a language without a default Bible. Note it was just a silent error and the user wouldn't see anything wrong, but it was an error nonetheless.

After fixing I realized we probably want TS to be stricter so it catches these before users hit them. I added a config option that is stricter around this issue: `noUncheckedIndexedAccess`