### PR TITLE
fix one small issue with missing reactivity

### DIFF
--- a/src/lib/components/file-manager/ViewTable.svelte
+++ b/src/lib/components/file-manager/ViewTable.svelte
@@ -46,9 +46,9 @@
             if (chapter.contents.length > 0 && chapter.chapterNumber) {
                 const chapterInfoExists = !!$biblesModuleBook.audioUrls.chapters[chapter.chapterNumber - 1];
                 if (chapterInfoExists) {
-                    const chapterObject = $biblesModuleBook.audioUrls.chapters[chapter.chapterNumber - 1];
-                    if (chapterObject) {
-                        chapterObject.resourceMenuItems = chapter.contents;
+                    if ($biblesModuleBook.audioUrls.chapters[chapter.chapterNumber - 1]) {
+                        $biblesModuleBook.audioUrls.chapters[chapter.chapterNumber - 1]!.resourceMenuItems =
+                            chapter.contents;
                     }
                 }
 


### PR DESCRIPTION
Because Svelte does reactivity through compilation, in order to catch a change to a reactive variable, the change must be done on the variable itself and not on a re-assignment.

e.g.
```
let thing = []

function doSomething() {
  thing[0] = true // this works

  const reassigned = thing
  reassigned[0] = true // this doesn't work since Svelte's compiler won't catch that `thing` itself was changed
}
```