### PR TITLE
improve cache busting for api endpoints

### DIFF
--- a/src/lib/api-endpoints.ts
+++ b/src/lib/api-endpoints.ts
@@ -1,0 +1,54 @@
+import type { ParentResourceName } from './types/resource';
+
+// In order to cache-bust an API endpoint when the response format is changed, increment the number after the endpoint path.
+// Note: This is a separate problem from breaking changes and only refers to non-breaking additive changes. It's probably
+//       still a good idea to avoid breaking changes where possible, since if an internet-connected client doesn't refresh
+//       to get the updated version we don't want them to have errors when they request new endpoints.
+
+// Use one of these endpoints like so (note the spread operator so that the fetch function gets the path and version as
+// separate arguments):
+//   fetchFromCacheOrApi(...languagesEndpoint())
+
+type ApiStringAndCacheBustVersion = [string, number];
+
+export function languagesEndpoint(): ApiStringAndCacheBustVersion {
+    return ['/languages', 2];
+}
+
+export function parentResourcesEndpoint(): ApiStringAndCacheBustVersion {
+    return ['/resources/parent-resources', 2];
+}
+
+export function biblesEndpoint(): ApiStringAndCacheBustVersion {
+    return ['/bibles', 1];
+}
+
+export function bookOfBibleEndpoint(bibleId: number | null, bookCode: string | null): ApiStringAndCacheBustVersion {
+    return [`/bibles/${bibleId}/book/${bookCode}`, 1];
+}
+
+export function biblesForLanguageEndpoint(languageId: number | undefined): ApiStringAndCacheBustVersion {
+    return [`/bibles/language/${languageId}`, 1];
+}
+
+export function resourcesByLanguageAndBookEndpoint(
+    languageId: number | undefined,
+    bookCode: string,
+    queryParams: string[]
+): ApiStringAndCacheBustVersion {
+    return [`/resources/language/${languageId}/book/${bookCode}?${queryParams.join('&')}`, 1];
+}
+
+export function passagesByLanguageAndParentResourceEndpoint(
+    languageId: number | undefined,
+    parentResourceName: ParentResourceName
+): ApiStringAndCacheBustVersion {
+    return [`/passages/language/${languageId}/resource/${parentResourceName}`, 1];
+}
+
+export function passageDetailsByIdAndLanguage(
+    passageId: number | string,
+    languageId: number | undefined
+): ApiStringAndCacheBustVersion {
+    return [`/passages/${passageId}/language/${languageId}`, 1];
+}

--- a/src/lib/components/file-manager/ResourceMenu.svelte
+++ b/src/lib/components/file-manager/ResourceMenu.svelte
@@ -15,6 +15,7 @@
     import type { ResourcesMenuItem } from '$lib/types/file-manager';
     import { ParentResourceName } from '$lib/types/resource';
     import { addFrontEndDataToResourcesMenuItems } from '$lib/utils/file-manager';
+    import { resourcesByLanguageAndBookEndpoint } from '$lib/api-endpoints';
 
     let resourcesMenuDiv: HTMLElement;
     let menuOpen = false;
@@ -40,7 +41,7 @@
 
             $resourcesApiModule = await addFrontEndDataToResourcesMenuItems(
                 await fetchFromCacheOrApi(
-                    `/resources/language/${$currentLanguageInfo?.id}/book/${selectedBookCode}?${queryParams.join('&')}`
+                    ...resourcesByLanguageAndBookEndpoint($currentLanguageInfo?.id, selectedBookCode, queryParams)
                 )
             );
         }

--- a/src/lib/components/file-manager/SelectBookMenu.svelte
+++ b/src/lib/components/file-manager/SelectBookMenu.svelte
@@ -13,6 +13,7 @@
         limitChaptersIfNecessary,
         allowedBooks,
     } from '$lib/stores/file-manager.store';
+    import { bookOfBibleEndpoint } from '$lib/api-endpoints';
 
     let bookMenuDiv: HTMLElement;
     let menuOpen = false;
@@ -28,7 +29,7 @@
     const handleBookClick = async (bookCode: string | null) => {
         toggleMenu();
         $biblesModuleBook = await addFrontEndDataToBiblesModuleBook(
-            await fetchFromCacheOrApi(`bibles/${firstBible.id}/book/${bookCode}`)
+            await fetchFromCacheOrApi(...bookOfBibleEndpoint(firstBible.id, bookCode))
         );
         $selectedBookCode = bookCode;
         limitChaptersIfNecessary(bookCode, biblesModuleBook);

--- a/src/lib/components/file-manager/ViewTable.svelte
+++ b/src/lib/components/file-manager/ViewTable.svelte
@@ -23,6 +23,7 @@
     import Image from '$lib/icons/Image.svelte';
     import ImageAndVideo from '$lib/icons/ImageAndVideo.svelte';
     import Video from '$lib/icons/Video.svelte';
+    import { passagesByLanguageAndParentResourceEndpoint } from '$lib/api-endpoints';
 
     let allChaptersSelected = false;
     let allChaptersCached = false;
@@ -38,7 +39,7 @@
 
         if ($resourcesMenu.some((resource) => resource.selected && resource.value === ParentResourceName.CBBTER)) {
             passageData = await fetchFromCacheOrApi(
-                `passages/language/${$currentLanguageInfo?.id}/resource/${ParentResourceName.CBBTER}`
+                ...passagesByLanguageAndParentResourceEndpoint($currentLanguageInfo?.id, ParentResourceName.CBBTER)
             );
         }
 

--- a/src/lib/data-cache.ts
+++ b/src/lib/data-cache.ts
@@ -35,13 +35,17 @@ const apiThumbnailRegex = /https:\/\/((qa|dev)\.)?api-bn\.aquifer\.bible\/resour
 const cdnRegex = /https:\/\/cdn\.aquifer\.bible.*/;
 export const staticUrlsMap: StaticUrlsMap = staticUrls;
 
-export async function fetchFromCacheOrApi(path: string) {
+export async function fetchFromCacheOrApi(path: string, cacheBustVersion: number) {
     if (!(await isCachedFromApi(path))) {
         partiallyDownloadedApiPaths.push(path);
     }
     try {
         const url = apiUrl(path).replace(/\/$/, '');
-        const response = await fetch(cachedOrRealUrl(url));
+        const response = await fetch(cachedOrRealUrl(url), {
+            // Set this header for the service worker layer to use. It will get stripped off before the request is
+            // actually made against the API.
+            headers: { 'X-Cache-Bust-Version': cacheBustVersion.toString() },
+        });
         if (response.status >= 400) {
             throw new Error('Bad HTTP response');
         }

--- a/src/lib/utils/data-handlers/resources/resource.ts
+++ b/src/lib/utils/data-handlers/resources/resource.ts
@@ -1,5 +1,5 @@
 import { env } from '$env/dynamic/public';
-import { fetchFromCacheOrApi, fetchFromCacheOrCdn } from '$lib/data-cache';
+import { fetchFromCacheOrCdn } from '$lib/data-cache';
 import { log } from '$lib/logger';
 import type { PassageResourceContent } from '$lib/types/passage';
 import { MediaType, type ResourceContentMetadata, type ResourceContentTiptap } from '$lib/types/resource';
@@ -17,20 +17,12 @@ export function resourceContentApiFullUrl(resourceContent: PassageResourceConten
     return env.PUBLIC_AQUIFER_API_URL + resourceContentApiPath(resourceContent);
 }
 
-function resourceThumbnailApiPath(resourceContent: PassageResourceContent) {
-    return `resources/${resourceContent.contentId}/thumbnail`;
-}
-
 export function resourceThumbnailApiFullUrl(resourceContent: PassageResourceContent) {
-    return env.PUBLIC_AQUIFER_API_URL + resourceThumbnailApiPath(resourceContent);
-}
-
-function resourceMetadataApiPath(resourceContent: PassageResourceContent) {
-    return `resources/${resourceContent.contentId}/metadata`;
+    return env.PUBLIC_AQUIFER_API_URL + `resources/${resourceContent.contentId}/thumbnail`;
 }
 
 export function resourceMetadataApiFullPath(resourceContent: PassageResourceContent) {
-    return env.PUBLIC_AQUIFER_API_URL + resourceMetadataApiPath(resourceContent);
+    return env.PUBLIC_AQUIFER_API_URL + `resources/${resourceContent.contentId}/metadata`;
 }
 
 export async function fetchTiptapForResourceContent(
@@ -52,7 +44,9 @@ export async function fetchMetadataForResourceContent(
     resourceContent: PassageResourceContent
 ): Promise<ResourceContentMetadata | null> {
     try {
-        return (await fetchFromCacheOrApi(resourceMetadataApiPath(resourceContent))) as ResourceContentMetadata | null;
+        return (await fetchFromCacheOrCdn(
+            resourceMetadataApiFullPath(resourceContent)
+        )) as ResourceContentMetadata | null;
     } catch (error) {
         // metadata not cached
         log.exception(error as Error);

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -11,6 +11,7 @@ import { log } from '$lib/logger';
 import { browserSupported } from '$lib/utils/browser';
 import { languages } from '$lib/stores/language.store';
 import { parentResources } from '$lib/stores/parent-resource.store';
+import { biblesEndpoint, languagesEndpoint, parentResourcesEndpoint } from '$lib/api-endpoints';
 
 export const ssr = false;
 
@@ -43,9 +44,9 @@ export const load: LayoutLoad = async () => {
         }
 
         const [fetchedLanguages, fetchedParentResources, _] = await Promise.all([
-            fetchFromCacheOrApi(`/languages`),
-            fetchFromCacheOrApi('/resources/parent-resources'),
-            fetchFromCacheOrApi('/bibles'),
+            fetchFromCacheOrApi(...languagesEndpoint()),
+            fetchFromCacheOrApi(...parentResourcesEndpoint()),
+            fetchFromCacheOrApi(...biblesEndpoint()),
         ]);
         languages.set(fetchedLanguages);
         parentResources.set(fetchedParentResources);

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -8,6 +8,7 @@
     import chevronLeft from 'svelte-awesome/icons/chevronLeft';
     import { goto } from '$app/navigation';
     import type { BaseBible } from '$lib/types/bible-text-content';
+    import { biblesEndpoint, parentResourcesEndpoint } from '$lib/api-endpoints';
 
     let licenseInfosPromise: Promise<ApiLicenseInfo[]> | null = null;
 
@@ -46,8 +47,8 @@
 
     async function fetchLicenses() {
         const [resourceLicenses, bibleLicenses] = await Promise.all([
-            fetchFromCacheOrApi('/resources/parent-resources') as Promise<ApiParentResource[]>,
-            fetchFromCacheOrApi('/bibles') as Promise<BaseBible[]>,
+            fetchFromCacheOrApi(...parentResourcesEndpoint()) as Promise<ApiParentResource[]>,
+            fetchFromCacheOrApi(...biblesEndpoint()) as Promise<BaseBible[]>,
         ]);
         const licenses = resourceLicenses
             .map((type) => type.licenseInfo)

--- a/src/routes/file-manager/+page.svelte
+++ b/src/routes/file-manager/+page.svelte
@@ -21,6 +21,7 @@
     import LanguageMenu from '$lib/components/file-manager/LanguageMenu.svelte';
     import SelectBookMenu from '$lib/components/file-manager/SelectBookMenu.svelte';
     import { addFrontEndDataToBiblesModuleBook } from '$lib/utils/file-manager';
+    import { biblesForLanguageEndpoint, bookOfBibleEndpoint } from '$lib/api-endpoints';
 
     let fetchAvailableResourcesPromise: Promise<void> | undefined;
 
@@ -29,16 +30,16 @@
             if (currentLanguageId) {
                 $fileManagerLoading = true;
 
-                $biblesModuleData = await fetchFromCacheOrApi(`bibles/language/${currentLanguageId}`);
+                $biblesModuleData = await fetchFromCacheOrApi(...biblesForLanguageEndpoint(currentLanguageId));
 
                 if ($biblesModuleData.length === 0) {
-                    $biblesModuleData = await fetchFromCacheOrApi(`bibles/language/1`);
+                    $biblesModuleData = await fetchFromCacheOrApi(...biblesForLanguageEndpoint(1));
                 }
 
                 if ($selectedBookCode) {
                     const firstBible = $biblesModuleData[0] || { id: null };
                     $biblesModuleBook = await addFrontEndDataToBiblesModuleBook(
-                        await fetchFromCacheOrApi(`bibles/${firstBible.id}/book/${$selectedBookCode}`)
+                        await fetchFromCacheOrApi(...bookOfBibleEndpoint(firstBible.id, $selectedBookCode))
                     );
                     limitChaptersIfNecessary($selectedBookCode, biblesModuleBook);
                 }

--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -55,7 +55,7 @@ declare let workbox: {
 
 const { clientsClaim } = workbox.core;
 const { registerRoute, NavigationRoute } = workbox.routing;
-const { NetworkOnly, CacheFirst, CacheOnly, StaleWhileRevalidate } = workbox.strategies;
+const { NetworkOnly, CacheFirst, NetworkFirst, CacheOnly, StaleWhileRevalidate } = workbox.strategies;
 const { BackgroundSyncPlugin } = workbox.backgroundSync;
 const { createHandlerBoundToURL, cleanupOutdatedCaches, precacheAndRoute } = workbox.precaching;
 const { RangeRequestsPlugin } = workbox.rangeRequests;
@@ -146,6 +146,7 @@ registerRoute(
         staleAfterDuration: 60 * 60 * API_CACHE_DURATION_IN_HOURS,
         plugins: [addApiKeyToAllRequestPlugin],
         CacheFirst,
+        NetworkFirst,
         StaleWhileRevalidate,
     }),
     'GET'

--- a/static/js/workbox-plugins/add-api-key-to-all-request-plugin.js
+++ b/static/js/workbox-plugins/add-api-key-to-all-request-plugin.js
@@ -22,10 +22,18 @@ class AddApiKeyToAllRequestPlugin {
      * @returns {Promise<Request>} A new request with the API key appended.
      */
     requestWillFetch = async (args) => {
-        const urlObj = new URL(args.request.url);
+        const { request } = args;
+        const urlObj = new URL(request.url);
         if (this.apikey) {
             urlObj.searchParams.append('api-key', this.apikey);
         }
-        return new Request(urlObj.toString(), args.request);
+
+        const modifiedHeaders = new Headers(request.headers);
+        modifiedHeaders.delete('X-Cache-Bust-Version');
+
+        return new Request(urlObj.toString(), {
+            ...request,
+            headers: modifiedHeaders,
+        });
     };
 }


### PR DESCRIPTION
When we make changes to the Well that rely on having fresh API data (like adding a new field onto an endpoint), we need a way to cache-bust so that the client doesn't use stale data and see errors.

This PR adds two layers:
- A new pattern for making requests that takes into account the cache bust version of the endpoint
- New logic in the service worker to refetch when the cache bust version changes