### PR TITLE
improve i18n linting in CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "build": "vite build",
         "preview": "vite preview",
         "test": "vitest",
-        "lint:unused-translations": "( eslint --max-warnings 0 --rule \"svelte-translate-check/unused-translations:error\" \"src/lib/i18n/locales/*.json\" || rm -f tmp/all-translate-calls.txt ) || exit 1",
+        "lint:unused-translations": "(eslint --max-warnings 0 --rule \"svelte-translate-check/unused-translations:error\" \"src/lib/i18n/locales/*.json\" ; ESLINT_STATUS=$? ; rm -f tmp/all-translate-calls.txt ; exit $ESLINT_STATUS)",
         "lint": "yarn format && eslint --max-warnings 0 --fix . && yarn lint:unused-translations && npx svelte-check",
         "lint:ci": "prettier --check \"**/*.{json,js,ts,css,html,svelte,cjs}\" && eslint --max-warnings 0 . && yarn lint:unused-translations && yarn svelte-check",
         "format": "prettier --write \"**/*.{json,js,ts,css,html,svelte,cjs}\"",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3775,7 +3775,7 @@ eslint-config-prettier@^9.0.0:
 
 "eslint-plugin-svelte-translate-check@https://github.com/BiblioNexusStudio/eslint-plugin-svelte-translate-check":
   version "1.0.0"
-  resolved "https://github.com/BiblioNexusStudio/eslint-plugin-svelte-translate-check#02ae88c9ac79604d502e2e54319b0dc5344dead3"
+  resolved "https://github.com/BiblioNexusStudio/eslint-plugin-svelte-translate-check#1952c2c18d99e4c9b578802f4e0004295beba848"
 
 eslint-plugin-svelte@^2.34.0:
   version "2.34.0"


### PR DESCRIPTION
These are updates to match how content-manager-web is now configured. It makes sure errors properly stop a merge and also updates to the newest version of the eslint plugin for checking I18n translations.