### PR TITLE
remove hardcoded types from library tab and switch to parent resource id for detecting types

### DIFF
--- a/src/lib/api-endpoints.ts
+++ b/src/lib/api-endpoints.ts
@@ -1,4 +1,4 @@
-import type { ParentResourceName } from './types/resource';
+import type { ParentResourceId } from './types/resource';
 
 // In order to cache-bust an API endpoint when the response format is changed, increment the number after the endpoint path.
 // Note: This is a separate problem from breaking changes and only refers to non-breaking additive changes. It's probably
@@ -16,8 +16,7 @@ export function languagesEndpoint(): ApiStringAndCacheBustVersion {
 }
 
 export function parentResourcesEndpoint(languageId?: number): ApiStringAndCacheBustVersion {
-    const url = languageId ? `/resources/parent-resources?languageId=${languageId}` : '/resources/parent-resources';
-    return [url, 3];
+    return [`/resources/parent-resources?languageId=${languageId ?? 1}`, 3];
 }
 
 export function biblesEndpoint(): ApiStringAndCacheBustVersion {
@@ -37,24 +36,21 @@ export function resourcesByLanguageAndBookEndpoint(
     bookCode: string,
     queryParams: string[]
 ): ApiStringAndCacheBustVersion {
-    return [`/resources/language/${languageId}/book/${bookCode}?${queryParams.sort().join('&')}`, 1];
+    return [`/resources/language/${languageId}/book/${bookCode}?${queryParams.sort().join('&')}`, 2];
 }
 
 export function passagesByLanguageAndParentResourceEndpoint(
     languageId: number | undefined,
-    parentResourceName: ParentResourceName
+    parentResourceId: ParentResourceId | undefined
 ): ApiStringAndCacheBustVersion {
-    return [`/passages/language/${languageId}/resource/${parentResourceName}`, 1];
+    return [`/passages/language/${languageId}/resource/${parentResourceId}`, 2];
 }
 
 export function booksAndChaptersByLanguageAndParentResourceEndpoint(
     languageId: number | undefined,
-    parentResourceName: ParentResourceName
+    parentResourceId: ParentResourceId | undefined
 ): ApiStringAndCacheBustVersion {
-    return [
-        `/resources/content/available-chapters?languageId=${languageId}&parentResourceName=${parentResourceName}`,
-        1,
-    ];
+    return [`/resources/content/available-chapters?languageId=${languageId}&parentResourceId=${parentResourceId}`, 2];
 }
 
 export function resourceContentForBookAndChapter(

--- a/src/lib/components/file-manager/ResourceMenu.svelte
+++ b/src/lib/components/file-manager/ResourceMenu.svelte
@@ -32,7 +32,7 @@
             const queryParams = resourcesMenu
                 .map((resource) => {
                     if (resource.selected && !resource.isBible) {
-                        return `parentResourceNames=${resource.value}`;
+                        return `parentResourceIds=${resource.parentResource?.id}`;
                     } else {
                         return '';
                     }
@@ -54,7 +54,6 @@
             ...$bibleDataForResourcesMenu,
             ...(await parentResourcesForCurrentLanguage()).map((pr) => ({
                 name: pr.displayName,
-                value: pr.shortName,
                 selected: false,
                 isBible: false,
                 display: true,

--- a/src/lib/i18n/locales/arb.json
+++ b/src/lib/i18n/locales/arb.json
@@ -328,32 +328,6 @@
         }
     },
     "resources": {
-        "types": {
-            "uwTranslationWords": {
-                "value": "المصطلحات الرئيسية (unfoldingWord)"
-            },
-            "CBBTER": {
-                "value": "CBBT-ER"
-            },
-            "ubsImages": {
-                "value": "صور (UBS)"
-            },
-            "tyndaleBibleDictionary": {
-                "value": "قاموس الكتاب المقدس (Tyndale)"
-            },
-            "tyndaleStudyNotes": {
-                "value": "ملاحظات الدراسة (Tyndale)"
-            },
-            "biblicaBibleDictionary": {
-                "value": "قاموس الكتاب المقدس (Biblica)"
-            },
-            "biblicaStudyNotes": {
-                "value": "ملاحظات الدراسة (Biblica)"
-            },
-            "videoBibleDictionary": {
-                "value": "فيديوهات (قاموس الكتاب المقدس بالفيديو)"
-            }
-        },
         "cbbt-er": {
             "step1": {
                 "value": "السمع والقلب"

--- a/src/lib/i18n/locales/eng.json
+++ b/src/lib/i18n/locales/eng.json
@@ -419,40 +419,6 @@
         }
     },
     "resources": {
-        "types": {
-            "uwTranslationWords": {
-                "value": "Key Terms (unfoldingWord)",
-                "_context": "Key terms from unfoldingWord"
-            },
-            "CBBTER": {
-                "value": "CBBT-ER",
-                "_context": "CBBT-ER guide from SRV"
-            },
-            "ubsImages": {
-                "value": "Images (UBS)",
-                "_context": "Images from the United Bible Society"
-            },
-            "tyndaleBibleDictionary": {
-                "value": "Bible Dictionary (Tyndale)",
-                "_context": "Tyndale Bible Dictionary"
-            },
-            "tyndaleStudyNotes": {
-                "value": "Study Notes (Tyndale)",
-                "_context": "Tyndale Study Notes"
-            },
-            "biblicaBibleDictionary": {
-                "value": "Bible Dictionary (Biblica)",
-                "_context": "Biblica Bible Dictionary"
-            },
-            "biblicaStudyNotes": {
-                "value": "Study Notes (Biblica)",
-                "_context": "Biblica Study Notes"
-            },
-            "videoBibleDictionary": {
-                "value": "Videos (Video Bible Dictionary)",
-                "_context": "Videos from the Video Bible Dictionary"
-            }
-        },
         "cbbt-er": {
             "step1": {
                 "value": "Hear and Heart",

--- a/src/lib/i18n/locales/fra.json
+++ b/src/lib/i18n/locales/fra.json
@@ -328,32 +328,6 @@
         }
     },
     "resources": {
-        "types": {
-            "uwTranslationWords": {
-                "value": "Terme Clé (unfoldingWord)"
-            },
-            "CBBTER": {
-                "value": "CBBT-ER"
-            },
-            "ubsImages": {
-                "value": "Images (UBS)"
-            },
-            "tyndaleBibleDictionary": {
-                "value": "Dictionnaire Biblique (Tyndale)"
-            },
-            "tyndaleStudyNotes": {
-                "value": "Notes d'Étude (Tyndale)"
-            },
-            "biblicaBibleDictionary": {
-                "value": "Dictionnaire Biblique (Biblica)"
-            },
-            "biblicaStudyNotes": {
-                "value": "Notes d'Étude (Biblica)"
-            },
-            "videoBibleDictionary": {
-                "value": "Vidéos (Dictionnaire Biblique Vidéo)"
-            }
-        },
         "cbbt-er": {
             "step1": {
                 "value": "Entendre et Ressentir"

--- a/src/lib/i18n/locales/hin.json
+++ b/src/lib/i18n/locales/hin.json
@@ -328,32 +328,6 @@
         }
     },
     "resources": {
-        "types": {
-            "uwTranslationWords": {
-                "value": "मुख्य शब्द (unfoldingWord)"
-            },
-            "CBBTER": {
-                "value": "CBBT-ER"
-            },
-            "ubsImages": {
-                "value": "छावियाँ (UBS)"
-            },
-            "tyndaleBibleDictionary": {
-                "value": "बाइबिल शब्दकोश (Tyndale)"
-            },
-            "tyndaleStudyNotes": {
-                "value": "अध्ययन नोट्स (Tyndale)"
-            },
-            "biblicaBibleDictionary": {
-                "value": "बाइबिल शब्दकोश (Biblica)"
-            },
-            "biblicaStudyNotes": {
-                "value": "अध्ययन नोट्स (Biblica)"
-            },
-            "videoBibleDictionary": {
-                "value": "वीडियो (Video Bible Dictionary)"
-            }
-        },
         "cbbt-er": {
             "step1": {
                 "value": "सुनें और दिल"

--- a/src/lib/i18n/locales/rus.json
+++ b/src/lib/i18n/locales/rus.json
@@ -382,39 +382,6 @@
         }
     },
     "resources": {
-        "types": {
-            "uwTranslationWords": {
-                "value": "Ключевой Термин (unfoldingWord)"
-            },
-            "CBBTER": {
-                "value": "CBBT-ER",
-                "_context": "Руководство по CBBT-ER от SRV"
-            },
-            "ubsImages": {
-                "value": "Изображения (ОБО)",
-                "_context": "Изображения от Объединенного Библейского Общества"
-            },
-            "tyndaleBibleDictionary": {
-                "value": "Библейский словарь (Тиндейл)",
-                "_context": "Библейский словарь Тиндейла"
-            },
-            "tyndaleStudyNotes": {
-                "value": "Примечания для изучения (Тиндейл)",
-                "_context": "Примечания к изучению от Тиндейла"
-            },
-            "biblicaBibleDictionary": {
-                "value": "Библейский словарь (Библика)",
-                "_context": "Библейский словарь от Библики"
-            },
-            "biblicaStudyNotes": {
-                "value": "Примечания к изучению (Библика)",
-                "_context": "Примечания к изучению от Библики"
-            },
-            "videoBibleDictionary": {
-                "value": "Видео (Видео Библейский Словарь)",
-                "_context": "Видео из Видео Библейского Словаря"
-            }
-        },
         "cbbt-er": {
             "step1": {
                 "value": "Слушание и сердце",

--- a/src/lib/i18n/locales/swh.json
+++ b/src/lib/i18n/locales/swh.json
@@ -382,39 +382,6 @@
         }
     },
     "resources": {
-        "types": {
-            "uwTranslationWords": {
-                "value": "Muhimu ya Muda (unfoldingWord)"
-            },
-            "CBBTER": {
-                "value": "CBBT-ER",
-                "_context": "Mwongozo wa CBBT-ER kutoka SRV"
-            },
-            "ubsImages": {
-                "value": "Picha (UBS)",
-                "_context": "Picha kutoka Muungano wa Umoja wa Biblia"
-            },
-            "tyndaleBibleDictionary": {
-                "value": "Kamusi ya Biblia (Tyndale)",
-                "_context": "Kamusi ya Biblia ya Tyndale"
-            },
-            "tyndaleStudyNotes": {
-                "value": "Vidokezo vya Utafiti (Tyndale)",
-                "_context": "Vidokezo vya Utafiti wa Tyndale"
-            },
-            "biblicaBibleDictionary": {
-                "value": "Kamusi ya Biblia (Biblia)",
-                "_context": "Kamusi ya Biblia ya Biblia"
-            },
-            "biblicaStudyNotes": {
-                "value": "Vidokezo vya Utafiti (Biblia)",
-                "_context": "Vidokezo vya Utafiti wa Biblia"
-            },
-            "videoBibleDictionary": {
-                "value": "Video (Kamusi ya Biblia ya Video)",
-                "_context": "Video kutoka kwa Kamusi ya Biblia ya Video"
-            }
-        },
         "cbbt-er": {
             "step1": {
                 "value": "Hear and Heart",

--- a/src/lib/i18n/locales/tpi.json
+++ b/src/lib/i18n/locales/tpi.json
@@ -328,32 +328,6 @@
         }
     },
     "resources": {
-        "types": {
-            "uwTranslationWords": {
-                "value": "Ol bikpela tok (unfoldingWord)"
-            },
-            "CBBTER": {
-                "value": "CBBT-ER"
-            },
-            "ubsImages": {
-                "value": "Piksa (UBS)"
-            },
-            "tyndaleBibleDictionary": {
-                "value": "Diksoneri bilong Buk Tambu(Tiendeil)"
-            },
-            "tyndaleStudyNotes": {
-                "value": "Nouts bilong stadi(Tiendeil)"
-            },
-            "biblicaBibleDictionary": {
-                "value": "DIksoneri bilong Buk Tambu(Biblika)"
-            },
-            "biblicaStudyNotes": {
-                "value": "Nouts bilong stadi(Biblika)"
-            },
-            "videoBibleDictionary": {
-                "value": "Ol vidio(Vidio Diksoneri bilong Buk Tambu)"
-            }
-        },
         "cbbt-er": {
             "step1": {
                 "value": "Harim na Lewa"

--- a/src/lib/stores/file-manager.store.ts
+++ b/src/lib/stores/file-manager.store.ts
@@ -22,7 +22,6 @@ export const biblesModuleData = writable<BiblesModule[]>([]);
 export const bibleDataForResourcesMenu = derived(biblesModuleData, (bibleData) => {
     return bibleData.map((bible, index) => ({
         name: bible.name,
-        value: bible.name,
         selected: index === 0 ? true : false,
         display: index === 0 ? true : false,
         isBible: true,

--- a/src/lib/stores/parent-resource.store.ts
+++ b/src/lib/stores/parent-resource.store.ts
@@ -5,10 +5,10 @@ import { browser } from '$app/environment';
 
 export const parentResources = writable<ApiParentResource[]>([]);
 
-export const parentResourceNameToInfoMap = derived(parentResources, ($parentResources) =>
+export const parentResourceIdToInfoMap = derived(parentResources, ($parentResources) =>
     groupBy(
         $parentResources,
-        (p) => p.shortName,
+        (p) => p.id,
         (r) => r[0]
     )
 );
@@ -20,15 +20,18 @@ export const guideResources = derived(parentResources, ($parentResources) =>
 const bibleWellCurrentGuide = 'LOCAL_BIBLE_WELL_CURRENT_GUIDE';
 
 export const locallyStoredGuide = derived(guideResources, ($guideResources) => {
-    const localGuideShortName = browser && localStorage.getItem(bibleWellCurrentGuide);
-    return $guideResources.find((r) => r.shortName === localGuideShortName);
+    const localGuideId =
+        browser &&
+        localStorage.getItem(bibleWellCurrentGuide) &&
+        parseInt(localStorage.getItem(bibleWellCurrentGuide)!);
+    return $guideResources.find((r) => r.id === localGuideId);
 });
 
 export const currentGuide = writable<ApiParentResource | undefined>(undefined);
 
 export function setCurrentGuide(guide: ApiParentResource | undefined) {
     if (guide) {
-        browser && localStorage.setItem(bibleWellCurrentGuide, guide.shortName);
+        browser && localStorage.setItem(bibleWellCurrentGuide, guide.id.toString());
         currentGuide.set(guide);
     }
 }

--- a/src/lib/stores/settings.store.ts
+++ b/src/lib/stores/settings.store.ts
@@ -1,14 +1,14 @@
 import { writable } from 'svelte/store';
 import { browser } from '$app/environment';
 import { type Setting, SettingShortNameEnum } from '../types/settings';
-import { ParentResourceName } from '$lib/types/resource';
+import { ParentResourceId } from '$lib/types/resource';
 
 const bibleWellSettingsInLocalStorage = 'BIBLE_WELL_SETTINGS_IN_LOCAL_STORAGE';
 
 const showOnlySrvResources: Setting = {
     value: true,
     shortName: SettingShortNameEnum.showOnlySrvResources,
-    parentResources: [ParentResourceName.CBBTER, ParentResourceName.VideoBibleDictionary],
+    parentResources: [ParentResourceId.CBBTER],
 };
 
 const defaultSettings = [showOnlySrvResources];

--- a/src/lib/types/file-manager.ts
+++ b/src/lib/types/file-manager.ts
@@ -1,5 +1,5 @@
 import type { DirectionCode } from '$lib/utils/language-utils';
-import type { ApiParentResource, MediaType, ParentResourceName } from './resource';
+import type { ApiParentResource, MediaType, ParentResourceId } from './resource';
 
 export type Url = string;
 export interface UrlWithMetadata {
@@ -23,7 +23,7 @@ export interface FileManagerResourceContentInfo {
     contentId: number;
     contentSize: number;
     mediaTypeName: MediaType;
-    parentResourceName: ParentResourceName;
+    parentResourceId: ParentResourceId;
     isResourceUrlCached?: boolean;
 }
 
@@ -118,7 +118,6 @@ export interface FooterInputs {
 
 export interface ResourcesMenuItem {
     name: string;
-    value: string;
     selected: boolean;
     isBible: boolean;
     display: boolean;
@@ -156,7 +155,7 @@ export interface BiblesModuleBook {
 
 export interface CbbterTextContent {
     contentId: number;
-    parentResourceName: string;
+    parentResourceId: string;
     mediaTypeName: string;
     contentSize: number;
 }

--- a/src/lib/types/resource.ts
+++ b/src/lib/types/resource.ts
@@ -1,12 +1,5 @@
-export enum ParentResourceName {
-    BiblicaBibleDictionary = 'BiblicaBibleDictionary',
-    BiblicaStudyNotes = 'BiblicaStudyNotes',
-    CBBTER = 'CBBTER',
-    TyndaleBibleDictionary = 'TyndaleBibleDictionary',
-    TyndaleStudyNotes = 'TyndaleStudyNotes',
-    UWTranslationWords = 'UWTranslationWords',
-    UbsImages = 'UbsImages',
-    VideoBibleDictionary = 'VideoBibleDictionary',
+export enum ParentResourceId {
+    CBBTER = 1,
 }
 
 export enum MediaType {
@@ -23,7 +16,7 @@ export enum ParentResourceComplexityLevel {
     Advanced = 'Advanced',
 }
 
-export const PredeterminedPassageGuides = [ParentResourceName.CBBTER];
+export const PredeterminedPassageGuides = [ParentResourceId.CBBTER];
 
 export enum ParentResourceType {
     None = 'None',
@@ -69,13 +62,13 @@ export interface AudioTypeMetadata {
 }
 
 export interface ApiParentResource {
-    shortName: ParentResourceName;
+    shortName: string;
     displayName: string;
     resourceType: ParentResourceType;
     complexityLevel: ParentResourceComplexityLevel;
     licenseInfo: ApiLicenseInfo | null;
     resourceCountForLanguage: number;
-    id: number;
+    id: ParentResourceId;
 }
 
 export interface ApiSingleLicense {
@@ -105,5 +98,5 @@ export interface ResourceContentInfo {
     id: number;
     mediaType: MediaType;
     resourceType: ParentResourceType;
-    parentResource: string;
+    parentResourceId: ParentResourceId;
 }

--- a/src/lib/types/settings.ts
+++ b/src/lib/types/settings.ts
@@ -1,4 +1,4 @@
-import type { ParentResourceName } from './resource';
+import type { ParentResourceId } from './resource';
 
 export enum SettingShortNameEnum {
     showOnlySrvResources = 'showOnlySrvResources',
@@ -7,5 +7,5 @@ export enum SettingShortNameEnum {
 export type Setting = {
     value: boolean;
     shortName: SettingShortNameEnum;
-    parentResources: ParentResourceName[];
+    parentResources: ParentResourceId[];
 };

--- a/src/lib/utils/data-handlers/resources/resource.ts
+++ b/src/lib/utils/data-handlers/resources/resource.ts
@@ -7,7 +7,6 @@ import type { FileManagerResourceContentInfo } from '$lib/types/file-manager';
 import type { BibleSection, WholeChapterBibleSection } from '$lib/types/bible';
 import {
     MediaType,
-    ParentResourceName,
     PredeterminedPassageGuides,
     type ResourceContentGroupedByVerses,
     type ResourceContentInfo,
@@ -117,7 +116,7 @@ export async function resourceContentsForBibleSection(
     // they only link to one verse. This would indicate it's the resource from the "other side" of the overlap.
     for (let i = resources.length - 1; i > 0; i--) {
         if (
-            PredeterminedPassageGuides.includes(resources[i]!.parentResource as ParentResourceName) &&
+            PredeterminedPassageGuides.includes(resources[i]!.parentResourceId) &&
             resources[i]!.occurrences === 1 &&
             !isForSingleVerse
         ) {

--- a/src/lib/utils/file-manager.ts
+++ b/src/lib/utils/file-manager.ts
@@ -16,7 +16,7 @@ import {
     resourceMetadataApiFullUrl,
     resourceThumbnailApiFullUrl,
 } from '$lib/utils/data-handlers/resources/resource';
-import { MediaType, ParentResourceName } from '$lib/types/resource';
+import { MediaType, ParentResourceId } from '$lib/types/resource';
 import { currentLanguageInfo } from '$lib/stores/language.store';
 import { get } from 'svelte/store';
 import { bibleBooksByBibleIdFullUrl } from './data-handlers/bible';
@@ -104,7 +104,8 @@ export const calculateUrlsWithMetadataToChange = (
                         if (resourceMenuItem.mediaTypeName === MediaType.Text) {
                             if (
                                 resourcesMenu.some(
-                                    ({ selected, value }) => selected && value === resourceMenuItem.parentResourceName
+                                    ({ selected, parentResource }) =>
+                                        selected && parentResource?.id === resourceMenuItem.parentResourceId
                                 )
                             ) {
                                 urlsAndSizesToDownload.push({
@@ -128,7 +129,8 @@ export const calculateUrlsWithMetadataToChange = (
                         if (resourceMenuItem.mediaTypeName === MediaType.Audio) {
                             if (
                                 resourcesMenu.some(
-                                    ({ selected, value }) => selected && value === resourceMenuItem.parentResourceName
+                                    ({ selected, parentResource }) =>
+                                        selected && parentResource?.id === resourceMenuItem.parentResourceId
                                 )
                             ) {
                                 urlsAndSizesToDownload.push({
@@ -197,7 +199,9 @@ export const calculateUrlsWithMetadataToChange = (
         }
     });
 
-    if (resourcesMenu.some(({ selected, value }) => selected && value === ParentResourceName.CBBTER)) {
+    if (
+        resourcesMenu.some(({ selected, parentResource }) => selected && parentResource?.id === ParentResourceId.CBBTER)
+    ) {
         biblesModuleBook.audioUrls?.chapters.forEach((chapter) => {
             if (chapter.cbbterResourceUrls?.length && chapter.cbbterResourceUrls?.length > 0) {
                 chapter.cbbterResourceUrls.forEach((cbbterResourceUrl) => {

--- a/src/routes/view-content/bible-menu/BookPassageSelectorPane.svelte
+++ b/src/routes/view-content/bible-menu/BookPassageSelectorPane.svelte
@@ -43,7 +43,7 @@
 
     async function fetchAvailablePassages(guide: ApiParentResource | undefined, _online: boolean) {
         if (guide) {
-            availablePassagesByBook = await passagesByBookAvailableForGuide(guide.shortName);
+            availablePassagesByBook = await passagesByBookAvailableForGuide(guide.id);
         } else {
             availablePassagesByBook = null;
         }

--- a/src/routes/view-content/data-fetchers.ts
+++ b/src/routes/view-content/data-fetchers.ts
@@ -16,7 +16,7 @@ import { range } from '$lib/utils/array';
 import { parseTiptapJsonToHtml } from '$lib/utils/tiptap-parsers';
 import {
     MediaType,
-    ParentResourceName,
+    ParentResourceId,
     type CbbtErAudioMetadata,
     type CbbtErAudioContent,
     type ResourceContentInfo,
@@ -123,7 +123,8 @@ export async function fetchBibleContent(passage: BibleSection, bible: FrontendBi
 
 async function getCbbterAudioForPassage(resourceContents: ResourceContentInfo[]): Promise<CbbtErAudioContent[]> {
     const allAudioResourceContent = resourceContents.filter(
-        ({ mediaType, parentResource }) => parentResource === ParentResourceName.CBBTER && mediaType === MediaType.Audio
+        ({ mediaType, parentResourceId }) =>
+            parentResourceId === ParentResourceId.CBBTER && mediaType === MediaType.Audio
     );
     return (
         await asyncMap(allAudioResourceContent, async (resourceContent) => {
@@ -148,7 +149,8 @@ async function getCbbterAudioForPassage(resourceContents: ResourceContentInfo[])
 
 async function getCbbterTextForPassage(resourceContents: ResourceContentInfo[]): Promise<CbbtErTextContent[]> {
     const allTextResourceContent = resourceContents.filter(
-        ({ mediaType, parentResource }) => parentResource === ParentResourceName.CBBTER && mediaType === MediaType.Text
+        ({ mediaType, parentResourceId }) =>
+            parentResourceId === ParentResourceId.CBBTER && mediaType === MediaType.Text
     );
     return (
         await asyncMap(allTextResourceContent, async (resourceContent) => {
@@ -181,7 +183,7 @@ async function getAdditionalResourcesForPassage(
 
     if (showOnlySrvResources?.value) {
         additionalResourceContent = resourceContents.filter((content) =>
-            showOnlySrvResources.parentResources.includes(content.parentResource as ParentResourceName)
+            showOnlySrvResources.parentResources.includes(content.parentResourceId)
         );
     } else {
         additionalResourceContent = resourceContents.filter(

--- a/src/routes/view-content/guide-menu/GuideMenu.svelte
+++ b/src/routes/view-content/guide-menu/GuideMenu.svelte
@@ -3,7 +3,7 @@
     import { settings } from '$lib/stores/settings.store';
     import { SettingShortNameEnum, type Setting } from '$lib/types/settings';
     import { setCurrentGuide, currentGuide } from '$lib/stores/parent-resource.store';
-    import type { ApiParentResource, ParentResourceName } from '$lib/types/resource';
+    import type { ApiParentResource, ParentResourceId } from '$lib/types/resource';
     import {
         guidesAvailableForBibleSection,
         guidesAvailableInCurrentLanguage,
@@ -49,7 +49,7 @@
 
         if (srvOnlySetting?.value === true) {
             return availableGuides.filter((guide) =>
-                srvOnlySetting.parentResources.includes(guide.shortName as ParentResourceName)
+                srvOnlySetting.parentResources.includes(guide.id as ParentResourceId)
             );
         }
 
@@ -83,7 +83,7 @@
                 </h3>
             {:else}
                 {#each availableGuides as guideResource}
-                    {@const isCurrentGuide = guideResource.shortName === $currentGuide?.shortName}
+                    {@const isCurrentGuide = guideResource.id === $currentGuide?.id}
                     <button
                         on:click={() => selectGuideAndHandleMenu(guideResource)}
                         class="my-2 flex w-11/12 rounded-xl p-4 {isCurrentGuide

--- a/src/routes/view-content/library-menu/AnyResourceSection.svelte
+++ b/src/routes/view-content/library-menu/AnyResourceSection.svelte
@@ -1,43 +1,43 @@
 <script lang="ts">
-    import { type ApiParentResource, ParentResourceType } from '$lib/types/resource';
+    import { type ApiParentResource, ParentResourceType, ParentResourceId } from '$lib/types/resource';
     import ImageResourceSection from './ImageResourceSection.svelte';
     import VideoResourceSection from './VideoResourceSection.svelte';
     import TextResourceSection from './TextResourceSection.svelte';
     import type { AnyResource } from './types';
-    import { calculateTitle } from './titles';
+    import { parseSubtitle, parseTitle } from './titles';
 
     export let parentResource: ApiParentResource;
     export let resources: AnyResource[];
     export let searchQuery: string;
     export let resourceSelected: (resource: AnyResource) => void;
-    export let showParentResourceFullscreen: (parentResourceName: string | null) => void;
+    export let showParentResourceFullscreen: (parentResourceId: ParentResourceId | null) => void;
 </script>
 
 {#if parentResource.resourceType === ParentResourceType.Images}
     <ImageResourceSection
-        title={calculateTitle(parentResource.shortName)}
-        subtitle={calculateTitle(parentResource.shortName, true)}
+        title={parseTitle(parentResource.displayName)}
+        subtitle={parseSubtitle(parentResource.displayName)}
         {resources}
         {resourceSelected}
         {searchQuery}
     />
 {:else if parentResource.resourceType === ParentResourceType.Videos}
     <VideoResourceSection
-        title={calculateTitle(parentResource.shortName)}
-        subtitle={calculateTitle(parentResource.shortName, true)}
+        title={parseTitle(parentResource.displayName)}
+        subtitle={parseSubtitle(parentResource.displayName)}
         {resources}
         {resourceSelected}
         {searchQuery}
     />
 {:else}
     <TextResourceSection
-        title={calculateTitle(parentResource.shortName)}
-        subtitle={calculateTitle(parentResource.shortName, true)}
+        title={parseTitle(parentResource.displayName)}
+        subtitle={parseSubtitle(parentResource.displayName)}
         {resources}
         {resourceSelected}
         {searchQuery}
         isFullscreen={false}
-        showParentResourceFullscreen={() => showParentResourceFullscreen(parentResource.shortName)}
+        showParentResourceFullscreen={() => showParentResourceFullscreen(parentResource.id)}
         dismissParentResourceFullscreen={() => showParentResourceFullscreen(null)}
     />
 {/if}

--- a/src/routes/view-content/library-menu/FullscreenTextResourceSection.svelte
+++ b/src/routes/view-content/library-menu/FullscreenTextResourceSection.svelte
@@ -2,23 +2,25 @@
     import { trapFocus } from '$lib/utils/trap-focus';
     import type { AnyResource, TextResource } from './types';
     import TextResourceSection from './TextResourceSection.svelte';
-    import { calculateTitle } from './titles';
+    import { parseSubtitle, parseTitle } from './titles';
+    import type { ApiParentResource, ParentResourceId } from '$lib/types/resource';
 
-    export let parentResourceName: string | null;
+    export let parentResourceIdToInfoMap: Record<ParentResourceId, ApiParentResource | undefined>;
+    export let parentResourceId: ParentResourceId | null;
     export let groupedResources: Record<string, AnyResource[]>;
     export let resourceSelected: (resource: TextResource) => void;
     export let dismissParentResourceFullscreen: () => void;
 
-    $: resources = ((parentResourceName && groupedResources[parentResourceName]) || []) as TextResource[];
+    $: resources = ((parentResourceId && groupedResources[parentResourceId]) || []) as TextResource[];
 
     let searchQuery = '';
 </script>
 
-{#if parentResourceName}
+{#if parentResourceId}
     <div use:trapFocus class="fixed inset-0 z-[45] flex w-full flex-col bg-primary-content px-4">
         <TextResourceSection
-            title={calculateTitle(parentResourceName)}
-            subtitle={calculateTitle(parentResourceName, true)}
+            title={parseTitle(parentResourceIdToInfoMap[parentResourceId]?.displayName)}
+            subtitle={parseSubtitle(parentResourceIdToInfoMap[parentResourceId]?.displayName)}
             {resources}
             bind:searchQuery
             {dismissParentResourceFullscreen}

--- a/src/routes/view-content/library-menu/titles.ts
+++ b/src/routes/view-content/library-menu/titles.ts
@@ -1,48 +1,5 @@
-import { ParentResourceName } from '$lib/types/resource';
-import { _ as translate } from 'svelte-i18n';
-import { get } from 'svelte/store';
-
-export function calculateTitle(parentResourceName: string, isSubtitle = false) {
-    const $translate = get(translate);
-    switch (parentResourceName) {
-        case ParentResourceName.UWTranslationWords:
-            return isSubtitle
-                ? parseSubtitle($translate('resources.types.uwTranslationWords.value'))
-                : parseTitle($translate('resources.types.uwTranslationWords.value'));
-        case ParentResourceName.CBBTER:
-            return isSubtitle
-                ? parseSubtitle($translate('resources.types.CBBTER.value'))
-                : parseTitle($translate('resources.types.CBBTER.value'));
-        case ParentResourceName.UbsImages:
-            return isSubtitle
-                ? parseSubtitle($translate('resources.types.ubsImages.value'))
-                : parseTitle($translate('resources.types.ubsImages.value'));
-        case ParentResourceName.VideoBibleDictionary:
-            return isSubtitle
-                ? parseSubtitle($translate('resources.types.videoBibleDictionary.value'))
-                : parseTitle($translate('resources.types.videoBibleDictionary.value'));
-        case ParentResourceName.TyndaleBibleDictionary:
-            return isSubtitle
-                ? parseSubtitle($translate('resources.types.tyndaleBibleDictionary.value'))
-                : parseTitle($translate('resources.types.tyndaleBibleDictionary.value'));
-        case ParentResourceName.TyndaleStudyNotes:
-            return isSubtitle
-                ? parseSubtitle($translate('resources.types.tyndaleStudyNotes.value'))
-                : parseTitle($translate('resources.types.tyndaleStudyNotes.value'));
-        case ParentResourceName.BiblicaBibleDictionary:
-            return isSubtitle
-                ? parseSubtitle($translate('resources.types.biblicaBibleDictionary.value'))
-                : parseTitle($translate('resources.types.biblicaBibleDictionary.value'));
-        case ParentResourceName.BiblicaStudyNotes:
-            return isSubtitle
-                ? parseSubtitle($translate('resources.types.biblicaStudyNotes.value'))
-                : parseTitle($translate('resources.types.biblicaStudyNotes.value'));
-        default:
-            return null;
-    }
-}
-
-function parseSubtitle(text: string) {
+export function parseSubtitle(text: string | undefined) {
+    if (!text) return '';
     const start = text.indexOf('(');
     if (start > 0) {
         return text.substring(start + 1, text.indexOf(')'));
@@ -50,7 +7,8 @@ function parseSubtitle(text: string) {
     return '';
 }
 
-function parseTitle(text: string) {
+export function parseTitle(text: string | undefined) {
+    if (!text) return '';
     const start = text.indexOf('(');
     if (start > 0 && start > 1) {
         return text.substring(0, start);

--- a/src/routes/view-content/library-menu/types.ts
+++ b/src/routes/view-content/library-menu/types.ts
@@ -1,4 +1,4 @@
-import type { ParentResourceName } from '$lib/types/resource';
+import type { ParentResourceId } from '$lib/types/resource';
 
 export type ResourcePaneTab = 'basic' | 'advanced' | 'searching';
 
@@ -10,12 +10,12 @@ export interface ImageOrVideoResource {
     url: string;
     duration?: number;
     thumbnailUrl?: string;
-    parentResourceName: ParentResourceName;
+    parentResourceId: ParentResourceId;
 }
 
 export interface TextResource {
     displayName: string | null;
     html: string;
     preview: string;
-    parentResourceName: ParentResourceName;
+    parentResourceId: ParentResourceId;
 }


### PR DESCRIPTION
The library tab now uses dynamic data from the /parent-resources endpoint. We also no longer use ShortName as the way to identify a given parent resource, but instead use the id.