### PR TITLE
restrict all resources when SRV Only is on, also disable by default

### DIFF
--- a/src/lib/stores/settings.store.ts
+++ b/src/lib/stores/settings.store.ts
@@ -1,14 +1,12 @@
 import { writable } from 'svelte/store';
 import { browser } from '$app/environment';
 import { type Setting, SettingShortNameEnum } from '../types/settings';
-import { ParentResourceId } from '$lib/types/resource';
 
 const bibleWellSettingsInLocalStorage = 'BIBLE_WELL_SETTINGS_IN_LOCAL_STORAGE';
 
 const showOnlySrvResources: Setting = {
-    value: true,
+    value: false,
     shortName: SettingShortNameEnum.showOnlySrvResources,
-    parentResources: [ParentResourceId.FIA],
 };
 
 const defaultSettings = [showOnlySrvResources];

--- a/src/lib/types/resource.ts
+++ b/src/lib/types/resource.ts
@@ -1,5 +1,6 @@
 export enum ParentResourceId {
     FIA = 1,
+    VideoBibleDictionary = 4,
     UwTranslationNotes = 11,
 }
 
@@ -16,6 +17,8 @@ export enum ParentResourceComplexityLevel {
     Basic = 'Basic',
     Advanced = 'Advanced',
 }
+
+export const SrvResources = [ParentResourceId.FIA, ParentResourceId.VideoBibleDictionary];
 
 export const PredeterminedPassageGuides = [ParentResourceId.FIA];
 

--- a/src/lib/types/settings.ts
+++ b/src/lib/types/settings.ts
@@ -1,5 +1,3 @@
-import type { ParentResourceId } from './resource';
-
 export enum SettingShortNameEnum {
     showOnlySrvResources = 'showOnlySrvResources',
 }
@@ -7,5 +5,4 @@ export enum SettingShortNameEnum {
 export type Setting = {
     value: boolean;
     shortName: SettingShortNameEnum;
-    parentResources: ParentResourceId[];
 };

--- a/src/lib/utils/data-handlers/resources/guides.ts
+++ b/src/lib/utils/data-handlers/resources/guides.ts
@@ -9,6 +9,7 @@ import {
     type ApiParentResource,
     PredeterminedPassageGuides,
     EnabledGuides,
+    SrvResources,
 } from '$lib/types/resource';
 import { resourceContentsForBibleSection, type AvailableChaptersForResource } from './resource';
 import {
@@ -20,6 +21,8 @@ import {
 import { range } from '$lib/utils/array';
 import { isOnline } from '$lib/stores/is-online.store';
 import type { ApiBibleBook, BibleSection, WholeChapterBibleSection } from '$lib/types/bible';
+import { settings } from '$lib/stores/settings.store';
+import { SettingShortNameEnum } from '$lib/types/settings';
 
 // for a given Bible section, return the guides available
 export async function guidesAvailableForBibleSection(
@@ -61,11 +64,16 @@ export async function guidesAvailableInCurrentLanguage() {
 }
 
 export async function parentResourcesForCurrentLanguage() {
+    const showOnlySrvResources = !!get(settings).find(
+        (setting) => setting.shortName === SettingShortNameEnum.showOnlySrvResources
+    )?.value;
     const languageId = get(currentLanguageInfo)?.id;
     const allParentResources = (await fetchFromCacheOrApi(
         ...parentResourcesEndpoint(languageId)
     )) as ApiParentResource[];
-    return allParentResources.filter((pr) => pr.enabled && pr.resourceCountForLanguage > 0);
+    return allParentResources.filter(
+        (pr) => (!showOnlySrvResources || SrvResources.includes(pr.id)) && pr.enabled && pr.resourceCountForLanguage > 0
+    );
 }
 
 async function allGuidesForLanguage() {

--- a/src/routes/view-content/data-fetchers.ts
+++ b/src/routes/view-content/data-fetchers.ts
@@ -15,8 +15,6 @@ import {
 } from '$lib/utils/data-handlers/resources/resource';
 import { preferredBibleIds } from '$lib/stores/preferred-bibles.store';
 import { log } from '$lib/logger';
-import { settings } from '$lib/stores/settings.store';
-import { SettingShortNameEnum, type Setting } from '$lib/types/settings';
 import { resourceContentsForBibleSection } from '$lib/utils/data-handlers/resources/resource';
 import type { BibleSection } from '$lib/types/bible';
 
@@ -113,21 +111,9 @@ export async function fetchBibleContent(passage: BibleSection, bible: FrontendBi
 }
 
 async function filterToAdditionalResourceInfo(resourceContents: ResourceContentInfo[]) {
-    let additionalResourceContent: ResourceContentInfo[] = [];
-
-    const showOnlySrvResources = get(settings).find((setting: Setting) => {
-        setting.shortName === SettingShortNameEnum.showOnlySrvResources;
-    });
-
-    if (showOnlySrvResources?.value) {
-        additionalResourceContent = resourceContents.filter((content) =>
-            showOnlySrvResources.parentResources.includes(content.parentResourceId)
-        );
-    } else {
-        additionalResourceContent = resourceContents.filter(
-            ({ resourceType }) => resourceType !== ParentResourceType.Guide
-        );
-    }
+    const additionalResourceContent = resourceContents.filter(
+        ({ resourceType }) => resourceType !== ParentResourceType.Guide
+    );
 
     return await asyncFilter(
         additionalResourceContent,
@@ -136,15 +122,7 @@ async function filterToAdditionalResourceInfo(resourceContents: ResourceContentI
 }
 
 async function filterToGuideResourceInfo(resourceContents: ResourceContentInfoWithFrontendData[]) {
-    const showOnlySrvResources = get(settings).find((setting: Setting) => {
-        setting.shortName === SettingShortNameEnum.showOnlySrvResources;
-    });
-
-    const onlyGuides = resourceContents.filter(
-        (content) =>
-            (content.resourceType === ParentResourceType.Guide && !showOnlySrvResources?.value) ||
-            showOnlySrvResources?.parentResources.includes(content.parentResourceId)
-    );
+    const onlyGuides = resourceContents.filter((content) => content.resourceType === ParentResourceType.Guide);
 
     return await asyncFilter(
         onlyGuides,

--- a/src/routes/view-content/guide-menu/GuideMenu.svelte
+++ b/src/routes/view-content/guide-menu/GuideMenu.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
     import { _ as translate } from 'svelte-i18n';
     import { settings } from '$lib/stores/settings.store';
-    import { SettingShortNameEnum, type Setting } from '$lib/types/settings';
+    import type { Setting } from '$lib/types/settings';
     import { setCurrentGuide, currentGuide } from '$lib/stores/parent-resource.store';
-    import { PredeterminedPassageGuides, type ApiParentResource, type ParentResourceId } from '$lib/types/resource';
+    import { PredeterminedPassageGuides, type ApiParentResource } from '$lib/types/resource';
     import {
         guidesAvailableForBibleSection,
         guidesAvailableInCurrentLanguage,
@@ -23,39 +23,19 @@
 
     async function fetchAvailableGuides(
         bibleSection: BibleSection | null,
-        settings: Setting[],
+        _settings: Setting[],
         _currentLanguageInfo: Language | undefined,
         _online: boolean
     ) {
-        let guides: ApiParentResource[] | undefined;
         if (bibleSection) {
-            guides = await guidesAvailableForBibleSection(bibleSection);
+            return await guidesAvailableForBibleSection(bibleSection);
         } else {
-            guides = await guidesAvailableInCurrentLanguage();
-        }
-        if (guides) {
-            return filterGuidesPerSettings(guides, settings);
-        } else {
-            return null;
+            return await guidesAvailableInCurrentLanguage();
         }
     }
 
     function selectGuideAndHandleMenu(guideResource: ApiParentResource) {
         setCurrentGuide(guideResource);
-    }
-
-    function filterGuidesPerSettings(availableGuides: ApiParentResource[], $settings: Setting[]) {
-        const srvOnlySetting = $settings.find(
-            (setting) => setting.shortName === SettingShortNameEnum.showOnlySrvResources
-        );
-
-        if (srvOnlySetting?.value === true) {
-            return availableGuides.filter((guide) =>
-                srvOnlySetting.parentResources.includes(guide.id as ParentResourceId)
-            );
-        }
-
-        return availableGuides;
     }
 
     function openGuideMenu() {


### PR DESCRIPTION
The "Show SRV Only" toggle is now off by default. We're also limiting resources across the app, in Resources tab, Library tab, and the download manager.