### PR TITLE
batch fetches for unfoldingWord Translation Notes for faster loads

### DIFF
--- a/src/lib/components/AudioPlayer/audio-player-state.ts
+++ b/src/lib/components/AudioPlayer/audio-player-state.ts
@@ -2,9 +2,14 @@ import { isSafariOnMacOrIOS } from '$lib/utils/browser';
 import { formatSecondsToTimeDisplay } from '$lib/utils/time';
 import { writable } from 'svelte/store';
 
+export enum AudioType {
+    mp3 = 'mp3',
+    webm = 'webm',
+}
+
 export interface AudioFileInfo {
     url: string;
-    type: 'webm' | 'mp3';
+    type: AudioType;
     startTime: number;
     endTime?: number | null;
 }

--- a/src/lib/utils/array.ts
+++ b/src/lib/utils/array.ts
@@ -57,3 +57,24 @@ export function sortByKey<T>(items: T[], key: keyof T, direction: 'asc' | 'desc'
         }
     });
 }
+
+// Filter out falsey values from an array (e.g. null, undefined, false, 0, "").
+export function filterBoolean<T>(items: (T | undefined | null)[] | undefined | null): T[] {
+    if (items === null || items === undefined) {
+        return [] as T[];
+    }
+    return items.filter(Boolean) as T[];
+}
+
+// Filter out elements in an array where the values at a given key are falsey (e.g. null, undefined, false, 0, "").
+export function filterBooleanByKey<T, K extends keyof T>(
+    items: (T | undefined | null)[] | undefined | null,
+    key: K
+): (T & { [P in K]: NonNullable<T[P]> })[] {
+    if (items === null || items === undefined) {
+        return [] as (T & { [P in K]: NonNullable<T[P]> })[];
+    }
+    return items.filter((item): item is T & { [P in K]: NonNullable<T[P]> } => {
+        return Boolean(item?.[key]);
+    });
+}

--- a/src/lib/utils/async-array.ts
+++ b/src/lib/utils/async-array.ts
@@ -13,7 +13,9 @@ export async function asyncSome<T>(array: T[], asyncPredicate: (element: T) => P
     return results.some(Boolean);
 }
 
-export async function asyncForEach<T>(
+// As the function name suggests, it's important to keep in mind that unlike a normal forEach, order is not guaranteed
+// by this function.
+export async function asyncUnorderedForEach<T>(
     array: T[],
     asyncCallback: (element: T, index: number, array: T[]) => Promise<void>
 ): Promise<void> {
@@ -25,24 +27,4 @@ export async function asyncMap<T, R>(
     asyncMapper: (element: T, index: number, array: T[]) => Promise<R>
 ): Promise<R[]> {
     return await Promise.all(array.map(asyncMapper));
-}
-
-export async function asyncReturnFirst<T, V>(array: T[], asyncApply: (element: T) => Promise<V>): Promise<V | null> {
-    for (const item of array) {
-        const result = await asyncApply(item);
-        if (result) return result;
-    }
-    return null;
-}
-
-export async function asyncReduce<T, R>(
-    array: T[],
-    reducer: (accumulator: R, element: T, index: number, array: T[]) => Promise<R>,
-    initialValue: R
-): Promise<R> {
-    let acc = initialValue;
-    for (let i = 0; i < array.length; i++) {
-        acc = await reducer(acc, array[i]!, i, array);
-    }
-    return acc;
 }

--- a/src/lib/utils/browser.ts
+++ b/src/lib/utils/browser.ts
@@ -2,6 +2,7 @@
 // @ts-nocheck
 
 import { browser } from '$app/environment';
+import { AudioType } from '$lib/components/AudioPlayer/audio-player-state';
 
 export function isSafariOnMacOrIOS() {
     return (
@@ -11,7 +12,7 @@ export function isSafariOnMacOrIOS() {
 }
 
 export function audioFileTypeForBrowser() {
-    return isSafariOnMacOrIOS() ? 'mp3' : 'webm';
+    return isSafariOnMacOrIOS() ? AudioType.mp3 : AudioType.webm;
 }
 
 export const browserSupported = browser && 'serviceWorker' in navigator;

--- a/src/lib/utils/file-manager.ts
+++ b/src/lib/utils/file-manager.ts
@@ -1,5 +1,5 @@
 import { METADATA_ONLY_FAKE_FILE_SIZE, isCachedFromCdn } from '$lib/data-cache';
-import { asyncForEach } from './async-array';
+import { asyncUnorderedForEach } from './async-array';
 import { audioFileTypeForBrowser } from './browser';
 import type {
     UrlWithMetadata,
@@ -234,7 +234,7 @@ export const addFrontEndDataToBiblesModuleBook = async (inputBiblesModuleBook: B
 
     inputBiblesModuleBook.isTextUrlCached = await isCachedFromCdn(inputBiblesModuleBook.textUrl);
 
-    await asyncForEach(inputBiblesModuleBook.audioUrls?.chapters ?? [], async (chapter) => {
+    await asyncUnorderedForEach(inputBiblesModuleBook.audioUrls?.chapters ?? [], async (chapter) => {
         chapter.isAudioUrlCached = await isCachedFromCdn(chapter[audioFileTypeForBrowser()].url);
         chapter.selected = false;
         chapter.allUrlsCached = false;
@@ -246,8 +246,8 @@ export const addFrontEndDataToBiblesModuleBook = async (inputBiblesModuleBook: B
 };
 
 export const addFrontEndDataToResourcesMenuItems = async (inputResourcesApiModule: ResourcesApiModule) => {
-    await asyncForEach(inputResourcesApiModule.chapters, async (chapter) => {
-        await asyncForEach(chapter.contents, async (content) => {
+    await asyncUnorderedForEach(inputResourcesApiModule.chapters, async (chapter) => {
+        await asyncUnorderedForEach(chapter.contents, async (content) => {
             content.isResourceUrlCached = await isCachedFromCdn(resourceContentApiFullUrl(content));
         });
     });

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -2,13 +2,14 @@
     import { onMount } from 'svelte';
     import { _ as translate } from 'svelte-i18n';
     import { fetchFromCacheOrApi } from '$lib/data-cache';
-    import type { ApiParentResource, ApiLicenseInfo, ApiSingleLicense } from '$lib/types/resource';
+    import type { ApiParentResource, ApiLicenseInfo } from '$lib/types/resource';
     import FullPageSpinner from '$lib/components/FullPageSpinner.svelte';
     import { Icon } from 'svelte-awesome';
     import chevronLeft from 'svelte-awesome/icons/chevronLeft';
     import { goto } from '$app/navigation';
     import type { BaseBible } from '$lib/types/bible';
     import { biblesEndpoint, parentResourcesEndpoint } from '$lib/api-endpoints';
+    import { filterBoolean } from '$lib/utils/array';
 
     let licenseInfosPromise: Promise<ApiLicenseInfo[]> | null = null;
 
@@ -17,7 +18,7 @@
     });
 
     function calculateLicenseDescription(licenseInfo: ApiLicenseInfo) {
-        const licenses = licenseInfo.licenses.map((license) => license['eng']).filter(Boolean) as ApiSingleLicense[];
+        const licenses = filterBoolean(licenseInfo.licenses.map((license) => license['eng']));
         if (licenses.length === 0) {
             return null;
         }
@@ -50,10 +51,9 @@
             fetchFromCacheOrApi(...parentResourcesEndpoint()) as Promise<ApiParentResource[]>,
             fetchFromCacheOrApi(...biblesEndpoint()) as Promise<BaseBible[]>,
         ]);
-        const licenses = resourceLicenses
-            .map((type) => type.licenseInfo)
-            .concat(bibleLicenses.map((bible) => bible.licenseInfo))
-            .filter(Boolean) as ApiLicenseInfo[];
+        const licenses = filterBoolean(
+            resourceLicenses.map((type) => type.licenseInfo).concat(bibleLicenses.map((bible) => bible.licenseInfo))
+        );
         return licenses.sort((a, b) => a.title.localeCompare(b.title));
     }
 </script>

--- a/src/routes/view-content/+page.svelte
+++ b/src/routes/view-content/+page.svelte
@@ -16,7 +16,6 @@
     import {
         createMultiClipAudioState,
         type MultiClipAudioState,
-        type AudioFileInfo,
     } from '$lib/components/AudioPlayer/audio-player-state';
     import { objectKeys } from '$lib/utils/typesafe-standard-lib';
     import {
@@ -64,6 +63,7 @@
     import GuideContent from './guide-content/GuideContent.svelte';
     import FullscreenTextResource from './library-resource-menu/FullscreenTextResource.svelte';
     import type { Language } from '$lib/types/file-manager';
+    import { filterBoolean } from '$lib/utils/array';
 
     let bibleData: BibleData | null = null;
     let resourceData: ResourceData | null = null;
@@ -185,14 +185,14 @@
         if (bibleData) {
             bibleData.biblesForTabs.forEach((bible) => {
                 if (!Object.keys(multiClipAudioStates).includes(bibleAudioKey(bible.id))) {
-                    const bibleAudioFiles = (
-                        bible.content?.chapters?.map(({ audioData }) => audioData).filter(Boolean) || []
+                    const bibleAudioFiles = filterBoolean(
+                        bible.content?.chapters?.map(({ audioData }) => audioData)
                     ).map((data) => ({
-                        url: data?.url,
-                        startTime: data?.startTimestamp || 0,
-                        endTime: data?.endTimestamp,
+                        url: data.url,
+                        startTime: data.startTimestamp || 0,
+                        endTime: data.endTimestamp,
                         type: audioFileTypeForBrowser(),
-                    })) as AudioFileInfo[];
+                    }));
                     if (bibleAudioFiles.length) {
                         multiClipAudioStates[bibleAudioKey(bible.id)] = createMultiClipAudioState(bibleAudioFiles);
                     }

--- a/src/routes/view-content/guide-content/FiaContent.svelte
+++ b/src/routes/view-content/guide-content/FiaContent.svelte
@@ -14,6 +14,7 @@
         MediaType,
         type ResourceContentTiptap,
     } from '$lib/types/resource';
+    import { filterBoolean, filterBooleanByKey } from '$lib/utils/array';
     import { asyncMap } from '$lib/utils/async-array';
     import { audioFileTypeForBrowser } from '$lib/utils/browser';
     import {
@@ -139,7 +140,7 @@
             ({ mediaType, parentResourceId }) =>
                 parentResourceId === ParentResourceId.FIA && mediaType === MediaType.Audio
         );
-        return (
+        return filterBoolean(
             await asyncMap(allAudioResourceContent, async (resourceContent) => {
                 try {
                     const metadata = await fetchMetadataForResourceContent(resourceContent);
@@ -147,9 +148,13 @@
                         audioFileTypeForBrowser()
                     ].steps;
                     if (!audioTypeSteps) return null;
-                    const steps = (
-                        await readFilesIntoObjectUrlsMapping(resourceContentApiFullUrl(resourceContent), audioTypeSteps)
-                    ).filter(({ url }) => !!url);
+                    const steps = filterBooleanByKey(
+                        await readFilesIntoObjectUrlsMapping(
+                            resourceContentApiFullUrl(resourceContent),
+                            audioTypeSteps
+                        ),
+                        'url'
+                    );
                     return { steps };
                 } catch (error) {
                     // nothing cached
@@ -157,7 +162,7 @@
                     return null;
                 }
             })
-        ).filter(Boolean) as FiaAudioContent[];
+        );
     }
 
     async function fetchText(resourceContents: ResourceContentInfo[]) {
@@ -165,7 +170,7 @@
             ({ mediaType, parentResourceId }) =>
                 parentResourceId === ParentResourceId.FIA && mediaType === MediaType.Text
         );
-        return (
+        return filterBoolean(
             await asyncMap(allTextResourceContent, async (resourceContent) => {
                 try {
                     const content = (await fetchFromCacheOrCdn(
@@ -183,7 +188,7 @@
                     return null;
                 }
             })
-        ).filter(Boolean) as FiaTextContent[];
+        );
     }
 </script>
 


### PR DESCRIPTION
Currently we use the batch endpoints for the download manager but not for pulling content for display.

This PR utilizes the batch endpoints for displaying unfoldingWord Translation Notes content. Rather than needing to fetch each content and metadata individually for each note (which there are about 2-5 per verse), we can batch all of the loads together.

However it's not as simple as just calling the batch endpoint every time since we aren't actually caching the batch endpoint URLs themselves. Instead we use the batch endpoint response to manually cache the individual content data.

This causes two problems:
1. When the user is offline if we tried a batch endpoint call it would fail.
2. When the user is online we will be fetching data that the user may already have cached. It essentially means every time we need to hit the server since it won't see anything as cached.

The solution is to first split the items based on if they're cached yet or not. Then call the batch endpoint for the uncached items and just do regular fetches for the cached items (since it'll just pull from cache).