### PR TITLE
fix hanging download manager when Bible doesn't have audio

### DIFF
--- a/src/lib/utils/file-manager.ts
+++ b/src/lib/utils/file-manager.ts
@@ -79,7 +79,12 @@ export const calculateUrlsWithMetadataToChange = (
 
     biblesModuleBook.audioUrls?.chapters.forEach((chapter) => {
         if (chapter.selected) {
-            if (bibleSelected && footerInputs.audio && !chapter.isAudioUrlCached) {
+            if (
+                bibleSelected &&
+                footerInputs.audio &&
+                chapter[audioFileTypeForBrowser()].url &&
+                !chapter.isAudioUrlCached
+            ) {
                 urlsAndSizesToDownload.push({
                     mediaType: MediaType.Audio,
                     url: chapter[audioFileTypeForBrowser()].url,


### PR DESCRIPTION
This fixes a bug Amber found that the download never completes when trying to download stuff in Arabic.