### PR TITLE
Now Closing All Pane Menus When Any Footer Tab Is Clicked

### DIFF
--- a/src/routes/view-content/+page.svelte
+++ b/src/routes/view-content/+page.svelte
@@ -255,8 +255,8 @@
             openBibleMenu();
         } else {
             closeAllPassagePageMenus();
-            closeAllPaneMenus();
         }
+        closeAllPaneMenus();
     }
 
     $: bibleSectionTitle = calculateBibleSectionTitle(currentBible, $selectedBibleSection);


### PR DESCRIPTION
I moved the closeAllPaneMenus function out of the if statement, and it will always fire when a footer tab is clicked.