### PR TITLE
use current language book name around app instead of current selected Bible

### DIFF
--- a/src/lib/components/TopNavBar.svelte
+++ b/src/lib/components/TopNavBar.svelte
@@ -13,8 +13,8 @@
     import { openGuideMenu, openBibleMenu } from '$lib/stores/passage-page.store';
     import { PredeterminedPassageGuides } from '$lib/types/resource';
     import { currentGuide } from '$lib/stores/parent-resource.store';
+    import { bibleSectionToReference } from '$lib/utils/bible-section-helpers';
 
-    export let bibleSectionTitle = '';
     export let bibleSection: BibleSection | null = null;
     export let bibles: FrontendBibleBook[] = [];
     let recordingModalOpen = false;
@@ -23,6 +23,9 @@
     export let guideShortName = '';
     export let showBookChapterVerseMenu: boolean;
     export let showBookPassageSelectorPane: boolean;
+    export let bookCodesToNames: Record<string, string> | undefined;
+
+    $: bibleSectionTitle = calculateBibleSectionTitle(bookCodesToNames, bibleSection);
 
     function handleWindowClick(event: MouseEvent) {
         const openDetails = document.querySelector('.dropdown[open]');
@@ -45,6 +48,17 @@
             } else {
                 showBookChapterVerseMenu = true;
             }
+        }
+    }
+
+    function calculateBibleSectionTitle(
+        bookCodesToNames: Record<string, string> | undefined,
+        bibleSection: BibleSection | null
+    ) {
+        if (bibleSection && bookCodesToNames) {
+            return `${bookCodesToNames[bibleSection.bookCode] ?? ''} ${bibleSectionToReference(bibleSection)}`;
+        } else {
+            return '';
         }
     }
 </script>

--- a/src/lib/utils/data-handlers/bible.ts
+++ b/src/lib/utils/data-handlers/bible.ts
@@ -214,17 +214,15 @@ async function isContentCachedForOffline(bibleSection: BibleSection, bookData: B
     return false;
 }
 
-export async function getBibleBookCodesToName(languageId: number | null = null, retry = true) {
-    const bibleData = (await fetchFromCacheOrApi(
-        ...biblesForLanguageEndpoint(languageId || get(currentLanguageInfo)?.id)
-    )) as ApiBible[];
+export async function getBibleBookCodesToName(languageId: number, retry = true) {
+    const bibleData = (await fetchFromCacheOrApi(...biblesForLanguageEndpoint(languageId))) as ApiBible[];
     if (bibleData[0]) {
         return bibleData[0].books.reduce(
             (output, { displayName, bookCode }) => ({ ...output, [bookCode]: displayName }),
             {} as Record<string, string>
         );
     } else {
-        if (retry && (languageId !== 1 || get(currentLanguageInfo)?.id !== 1)) {
+        if (retry && languageId !== 1) {
             return getBibleBookCodesToName(1, false);
         }
     }

--- a/src/routes/view-content/+page.svelte
+++ b/src/routes/view-content/+page.svelte
@@ -28,10 +28,14 @@
         fetchBibleData,
     } from './data-fetchers';
     import { preferredBibleIds } from '$lib/stores/preferred-bibles.store';
-    import type { BibleBookContentDetails, FrontendBibleBook } from '$lib/types/bible';
-    import { cacheBibleMetadata, cacheBiblesForBibleSection } from '$lib/utils/data-handlers/bible';
+    import type { BibleBookContentDetails } from '$lib/types/bible';
+    import {
+        cacheBibleMetadata,
+        cacheBiblesForBibleSection,
+        getBibleBookCodesToName,
+    } from '$lib/utils/data-handlers/bible';
     import { isOnline } from '$lib/stores/is-online.store';
-    import { lookupLanguageInfoById } from '$lib/stores/language.store';
+    import { currentLanguageInfo, lookupLanguageInfoById } from '$lib/stores/language.store';
     import MainMenu from '$lib/components/MainMenu.svelte';
     import { currentGuide, locallyStoredGuide } from '$lib/stores/parent-resource.store';
     import {
@@ -60,10 +64,10 @@
     import SettingsMenu from './settings-menu/SettingsMenu.svelte';
     import type { BibleSection } from '$lib/types/bible';
     import BibleUnavailable from './BibleUnavailable.svelte';
-    import { bibleSectionToReference } from '$lib/utils/bible-section-helpers';
     import QuickShare from './quick-share/QuickShare.svelte';
     import GuideContent from './guide-content/GuideContent.svelte';
     import FullscreenTextResource from './library-resource-menu/FullscreenTextResource.svelte';
+    import type { Language } from '$lib/types/file-manager';
 
     let bibleData: BibleData | null = null;
     let resourceData: ResourceData | null = null;
@@ -81,6 +85,7 @@
     let multiClipAudioStates: Record<string, MultiClipAudioState> = {};
     let preferredBiblesModalOpen = false;
     let audioPlayerKey: string | undefined;
+    let bookCodesToNames: Record<string, string> | undefined;
 
     $: {
         baseFetchPromise = fetchBase($selectedBibleSection); // when the Bible section changes, refetch
@@ -91,6 +96,7 @@
     $: selectedTab === PassagePageTabEnum.Bible && setBibleAudioPlayerForBible(selectedBibleId);
     $: audioPlayerShowing = audioPlayerKey && !!multiClipAudioStates[audioPlayerKey];
     $: currentBible = bibleData?.biblesForTabs.find((bible) => bible.id === selectedBibleId);
+    $: fetchBibleBookCodeToName($currentLanguageInfo);
 
     $: setStoredGuide($locallyStoredGuide);
 
@@ -223,20 +229,15 @@
         }
     }
 
-    function calculateBibleSectionTitle(
-        currentBible: FrontendBibleBook | undefined,
-        bibleSection: BibleSection | null
-    ) {
-        if (bibleSection) {
-            return `${currentBible?.bookMetadata?.displayName ?? ''} ${bibleSectionToReference(bibleSection)}`;
-        } else {
-            return '';
-        }
-    }
-
     function closeAllPaneMenus() {
         isShowingBookPassageSelectorPane = false;
         isShowingBookChapterSelectorPane = false;
+    }
+
+    async function fetchBibleBookCodeToName(currentLanguageInfo: Language | undefined) {
+        if (currentLanguageInfo) {
+            bookCodesToNames = await getBibleBookCodesToName(currentLanguageInfo.id);
+        }
     }
 
     function handleSelectedTabMenu(tab: PassagePageTabEnum) {
@@ -259,7 +260,6 @@
         }
     }
 
-    $: bibleSectionTitle = calculateBibleSectionTitle(currentBible, $selectedBibleSection);
     $: handleSelectedTabMenu(selectedTab);
 
     $: showOrDismissBookPassageSelectorPane(isShowingBookPassageSelectorPane);
@@ -285,11 +285,13 @@
     bind:bookPassageSelectorPane
     bind:isShowing={isShowingBookPassageSelectorPane}
     bind:tab={selectedTab}
+    {bookCodesToNames}
 />
 <BookChapterSelectorPane
     bind:bookChapterSelectorPane
     bind:isShowing={isShowingBookChapterSelectorPane}
     filterByCurrentGuide={selectedTab === PassagePageTabEnum.Guide}
+    {bookCodesToNames}
 />
 
 <FullscreenTextResource bind:fullscreenTextResourceStack />
@@ -343,7 +345,7 @@
         {#if $passagePageShownMenu === null || $passagePageShownMenu === PassagePageMenuEnum.resources}
             <TopNavBar
                 bind:preferredBiblesModalOpen
-                {bibleSectionTitle}
+                {bookCodesToNames}
                 bibleSection={$selectedBibleSection}
                 bibles={bibleData?.availableBibles ?? []}
                 tab={selectedTab}

--- a/src/routes/view-content/bible-menu/BookChapterSelectorPane.svelte
+++ b/src/routes/view-content/bible-menu/BookChapterSelectorPane.svelte
@@ -20,6 +20,7 @@
     export let bookChapterSelectorPane: CupertinoPane;
     export let isShowing: boolean;
     export let filterByCurrentGuide: boolean;
+    export let bookCodesToNames: Record<string, string> | undefined;
 
     let currentBook: ApiBibleBook;
     let currentChapter: ApiBibleChapter | null = null;
@@ -217,6 +218,13 @@
         return formattedRange;
     }
 
+    function bookName(book: ApiBibleBook | undefined) {
+        if (book) {
+            return bookCodesToNames?.[book.code] ?? book.localizedName;
+        }
+        return '';
+    }
+
     onMount(async () => {
         bookChapterSelectorPane = new CupertinoPane('#book-chapter-verse-selector-pane', {
             backdrop: true,
@@ -251,7 +259,7 @@
     $: verseGoButtonDisabled = firstSelectedVerse === null;
     $: currentChapterSelected = currentChapter?.number && currentChapter?.number > 0;
     $: verseTitle = formatBibleVerseRange(
-        currentBook?.localizedName,
+        bookName(currentBook),
         firstSelectedVerse?.chapterNumber || '',
         firstSelectedVerse?.number || '',
         lastSelectedVerse?.chapterNumber || '',
@@ -297,13 +305,13 @@
                                         : 'border'}"
                                     data-app-insights-event-name={`book-chapter-selector-pane-${book?.code}-selected`}
                                 >
-                                    {book.localizedName}
+                                    {bookName(book)}
                                 </button>
                             {/each}
                         </div>
                     {/if}
                     {#if currentStep === steps.two}
-                        <h3 class="mb-4 block self-start text-lg font-bold">{currentBook.localizedName}</h3>
+                        <h3 class="mb-4 block self-start text-lg font-bold">{bookName(currentBook)}</h3>
                         <h4 class="mb-4 block self-start">{currentStep.subtitle}</h4>
                         <div class="w-full flex-grow overflow-y-scroll">
                             <div class="grid w-full grid-cols-5 gap-4">
@@ -340,7 +348,7 @@
                                     class="btn me-4 block {isCurrentChapter && 'bg-blue-500 text-white'}"
                                     data-app-insights-event-name={`book-chapter-selector-pane-${currentBook.code}-chapter-carousel-${chapter.number}-selected`}
                                 >
-                                    <span class="me-1">{currentBook.localizedName}</span><span>{chapter.number}</span>
+                                    <span class="me-1">{bookName(currentBook)}</span><span>{chapter.number}</span>
                                 </button>
                             {/each}
                         </div>

--- a/src/routes/view-content/bible-menu/BookPassageSelectorPane.svelte
+++ b/src/routes/view-content/bible-menu/BookPassageSelectorPane.svelte
@@ -8,7 +8,6 @@
     import type { BibleSection } from '$lib/types/bible';
     import { closeAllPassagePageMenus } from '$lib/stores/passage-page.store';
     import ChevronLeftIcon from '$lib/icons/ChevronLeftIcon.svelte';
-    import { getBibleBookCodesToName } from '$lib/utils/data-handlers/bible';
     import { currentGuide } from '$lib/stores/parent-resource.store';
     import { PredeterminedPassageGuides, type ApiParentResource } from '$lib/types/resource';
     import type { BasePassagesByBook } from '$lib/types/passage';
@@ -18,6 +17,7 @@
     export let bookPassageSelectorPane: CupertinoPane;
     export let isShowing: boolean;
     export let tab: PassagePageTabEnum;
+    export let bookCodesToNames: Record<string, string> | undefined;
 
     let steps = {
         one: { title: $translate('page.BookPassageSelectorMenu.stepOneTitle.value') },
@@ -27,8 +27,6 @@
     let availablePassagesByBook: BasePassagesByBook[] | null = null;
 
     $: selectedBookInfo = $selectedBookIndex === 'default' ? null : availablePassagesByBook?.[$selectedBookIndex];
-
-    let bookCodesToNames: Record<string, string> | undefined;
 
     function setBookAndChangeSteps(index: number) {
         currentStep = steps.two;
@@ -68,7 +66,6 @@
                 onBackdropTap: () => (isShowing = false),
             },
         });
-        bookCodesToNames = await getBibleBookCodesToName();
     });
 </script>
 

--- a/src/routes/view-content/library-resource-menu/VideoResourceSection.svelte
+++ b/src/routes/view-content/library-resource-menu/VideoResourceSection.svelte
@@ -79,7 +79,7 @@
     >
         {#each unfilteredResources as video}
             <button
-                class="carousel-item me-2 w-32 flex-col {showingResources.includes(video) ? 'visible' : 'hidden'}"
+                class="carousel-item me-8 w-32 flex-col {showingResources.includes(video) ? 'visible' : 'hidden'}"
                 on:click={() => resourceSelected(video)}
                 data-app-insights-event-name="video-resource-button-clicked"
             >


### PR DESCRIPTION
Per feedback from Ben, the app should use Bible book names based on the current language, NOT the current selected Bible.