### PR TITLE
allGoToPassageButtonsNowCheckOnGuideStatus

### DIFF
--- a/src/lib/components/TopNavBar.svelte
+++ b/src/lib/components/TopNavBar.svelte
@@ -39,15 +39,11 @@
     }
 
     function handlePassageButton() {
-        if (tab === PassagePageTabEnum.Bible) {
+        const currentGuideId = $currentGuide?.id;
+        if (currentGuideId && PredeterminedPassageGuides.includes(currentGuideId)) {
+            showBookPassageSelectorPane = true;
+        } else {
             showBookChapterVerseMenu = true;
-        } else if (tab === PassagePageTabEnum.Guide || tab === PassagePageTabEnum.Resources) {
-            const currentGuideId = $currentGuide?.id;
-            if (currentGuideId && PredeterminedPassageGuides.includes(currentGuideId)) {
-                showBookPassageSelectorPane = true;
-            } else {
-                showBookChapterVerseMenu = true;
-            }
         }
     }
 

--- a/src/routes/view-content/+page.svelte
+++ b/src/routes/view-content/+page.svelte
@@ -440,7 +440,10 @@
         <LibraryResourceMenu bind:fullscreenTextResourceStack resources={undefined} tab={selectedTab} />
     {/if}
     {#if $passagePageShownMenu === PassagePageMenuEnum.bible}
-        <BibleMenu bind:showBookChapterVerseMenu={isShowingBookChapterSelectorPane} />
+        <BibleMenu
+            bind:showBookChapterVerseMenu={isShowingBookChapterSelectorPane}
+            bind:showBookPassageSelectorPane={isShowingBookPassageSelectorPane}
+        />
     {/if}
     {#if $passagePageShownMenu === PassagePageMenuEnum.settings}
         <SettingsMenu />

--- a/src/routes/view-content/bible-menu/BibleMenu.svelte
+++ b/src/routes/view-content/bible-menu/BibleMenu.svelte
@@ -6,13 +6,21 @@
     import { availableBibles } from '$lib/utils/data-handlers/bible';
     import FullPageSpinner from '$lib/components/FullPageSpinner.svelte';
     import SwishHeader from '$lib/components/SwishHeader.svelte';
+    import { currentGuide } from '$lib/stores/parent-resource.store';
+    import { PredeterminedPassageGuides } from '$lib/types/resource';
 
     export let showBookChapterVerseMenu: boolean;
+    export let showBookPassageSelectorPane: boolean;
 
     $: availableBiblesPromise = availableBibles($isOnline);
 
     function openBookChapterVerseMenu() {
-        showBookChapterVerseMenu = true;
+        const currentGuideId = $currentGuide?.id;
+        if (currentGuideId && PredeterminedPassageGuides.includes(currentGuideId)) {
+            showBookPassageSelectorPane = true;
+        } else {
+            showBookChapterVerseMenu = true;
+        }
     }
 
     function updatePreferredBibleIds(id: number, isChecked: boolean) {


### PR DESCRIPTION
After some discussion with Ben Jore, all go-to passage buttons will now check on the selected guide status and determine what pane menu to bring up. 