### PR TITLE
assorted small Bible Well improvements

### DIFF
--- a/src/lib/components/FullPageSpinner.svelte
+++ b/src/lib/components/FullPageSpinner.svelte
@@ -3,6 +3,6 @@
     import { Icon } from 'svelte-awesome';
 </script>
 
-<div class="flex h-full w-full flex-row">
+<div class="flex h-full w-full flex-row bg-white">
     <Icon class="mx-auto self-center stroke-base-content" data={refresh} scale={2} spin />
 </div>

--- a/src/lib/stores/parent-resource.store.ts
+++ b/src/lib/stores/parent-resource.store.ts
@@ -30,8 +30,6 @@ export const locallyStoredGuide = derived(guideResources, ($guideResources) => {
 export const currentGuide = writable<ApiParentResource | undefined>(undefined);
 
 export function setCurrentGuide(guide: ApiParentResource | undefined) {
-    if (guide) {
-        browser && localStorage.setItem(bibleWellCurrentGuide, guide.id.toString());
-        currentGuide.set(guide);
-    }
+    browser && localStorage.setItem(bibleWellCurrentGuide, guide?.id?.toString() ?? '');
+    currentGuide.set(guide);
 }

--- a/src/lib/stores/passage-page.store.ts
+++ b/src/lib/stores/passage-page.store.ts
@@ -1,4 +1,7 @@
-import { writable } from 'svelte/store';
+import { get, writable } from 'svelte/store';
+import { PassagePageTabEnum } from '../../routes/view-content/data-fetchers';
+import { currentGuide } from './parent-resource.store';
+import { selectedBibleSection } from './passage-form.store';
 
 export enum PassagePageMenuEnum {
     guide = 'guide',
@@ -25,10 +28,6 @@ export function openMainMenu() {
     passagePageShownMenu.set(PassagePageMenuEnum.main);
 }
 
-export function openLibraryMenu() {
-    passagePageShownMenu.set(PassagePageMenuEnum.library);
-}
-
 export function openBibleMenu() {
     passagePageShownMenu.set(PassagePageMenuEnum.bible);
 }
@@ -41,10 +40,22 @@ export function openShareMenu() {
     passagePageShownMenu.set(PassagePageMenuEnum.share);
 }
 
-export function openResourcesMenu() {
-    passagePageShownMenu.set(PassagePageMenuEnum.resources);
-}
-
-export function closeAllPassagePageMenus() {
-    passagePageShownMenu.set(null);
+export function recalculatePanesAndMenus(tab: PassagePageTabEnum, callback?: () => void) {
+    if (tab === PassagePageTabEnum.LibraryMenu) {
+        passagePageShownMenu.set(PassagePageMenuEnum.library);
+    } else if (tab === PassagePageTabEnum.Resources) {
+        passagePageShownMenu.set(PassagePageMenuEnum.resources);
+    } else if (
+        tab === PassagePageTabEnum.Guide &&
+        (get(currentGuide) === undefined || get(selectedBibleSection) === null)
+    ) {
+        openGuideMenu();
+    } else if (tab === PassagePageTabEnum.MainMenu) {
+        openMainMenu();
+    } else if (tab === PassagePageTabEnum.Bible && get(selectedBibleSection) === null) {
+        openBibleMenu();
+    } else {
+        passagePageShownMenu.set(null);
+    }
+    callback?.();
 }

--- a/src/lib/utils/bible-section-helpers.ts
+++ b/src/lib/utils/bible-section-helpers.ts
@@ -37,6 +37,9 @@ export function bibleSectionsEqual(passage1: BibleSection, passage2: BibleSectio
 
 export function bibleSectionToReference(bibleSection: BibleSection): string {
     if (bibleSection.startChapter === bibleSection.endChapter) {
+        if (bibleSection.startVerse === bibleSection.endVerse) {
+            return `${bibleSection.startChapter}:${bibleSection.startVerse}`;
+        }
         return `${bibleSection.startChapter}:${bibleSection.startVerse}-${bibleSection.endVerse}`;
     }
     return `${bibleSection.startChapter}:${bibleSection.startVerse}-${bibleSection.endChapter}:${bibleSection.endVerse}`;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4,9 +4,11 @@
     import LanguageIcon from '$lib/icons/LanguageIcon.svelte';
     import { selectedBibleSection } from '$lib/stores/passage-form.store';
     import { onMount } from 'svelte';
+    import { setCurrentGuide } from '$lib/stores/parent-resource.store';
 
     onMount(() => {
         selectedBibleSection.set(null);
+        setCurrentGuide(undefined);
     });
 </script>
 

--- a/src/routes/view-content/+page.svelte
+++ b/src/routes/view-content/+page.svelte
@@ -41,12 +41,8 @@
     import {
         PassagePageMenuEnum,
         passagePageShownMenu,
-        openMainMenu,
-        closeAllPassagePageMenus,
-        openLibraryMenu,
         openGuideMenu,
-        openBibleMenu,
-        openResourcesMenu,
+        recalculatePanesAndMenus,
     } from '$lib/stores/passage-page.store';
     import GuideMenu from './guide-menu/GuideMenu.svelte';
     import { onMount } from 'svelte';
@@ -240,27 +236,7 @@
         }
     }
 
-    function handleSelectedTabMenu(tab: PassagePageTabEnum) {
-        if (tab === PassagePageTabEnum.LibraryMenu) {
-            openLibraryMenu();
-        } else if (tab === PassagePageTabEnum.Resources) {
-            openResourcesMenu();
-        } else if (
-            tab === PassagePageTabEnum.Guide &&
-            ($currentGuide === undefined || $selectedBibleSection === null)
-        ) {
-            openGuideMenu();
-        } else if (tab === PassagePageTabEnum.MainMenu) {
-            openMainMenu();
-        } else if (tab === PassagePageTabEnum.Bible && $selectedBibleSection === null) {
-            openBibleMenu();
-        } else {
-            closeAllPassagePageMenus();
-        }
-        closeAllPaneMenus();
-    }
-
-    $: handleSelectedTabMenu(selectedTab);
+    $: recalculatePanesAndMenus(selectedTab, closeAllPaneMenus);
 
     $: showOrDismissBookPassageSelectorPane(isShowingBookPassageSelectorPane);
     $: showOrDismissBookChapterSelectorPane(isShowingBookChapterSelectorPane);
@@ -292,6 +268,7 @@
     bind:isShowing={isShowingBookChapterSelectorPane}
     filterByCurrentGuide={selectedTab === PassagePageTabEnum.Guide}
     {bookCodesToNames}
+    bind:tab={selectedTab}
 />
 
 <FullscreenTextResource bind:fullscreenTextResourceStack />

--- a/src/routes/view-content/bible-menu/BookChapterSelectorPane.svelte
+++ b/src/routes/view-content/bible-menu/BookChapterSelectorPane.svelte
@@ -8,7 +8,6 @@
     import arrowRight from 'svelte-awesome/icons/arrowRight';
     import type { ApiBibleBook, FrontEndVerseForSelectionPane, ApiBibleChapter } from '$lib/types/bible';
     import { selectedBibleSection } from '$lib/stores/passage-form.store';
-    import { closeAllPassagePageMenus } from '$lib/stores/passage-page.store';
     import { currentLanguageInfo } from '$lib/stores/language.store';
     import type { Language } from '$lib/types/file-manager';
     import { isOnline } from '$lib/stores/is-online.store';
@@ -16,11 +15,14 @@
     import { bibleChaptersByBookAvailableForGuide } from '$lib/utils/data-handlers/resources/guides';
     import { currentGuide } from '$lib/stores/parent-resource.store';
     import type { ApiParentResource } from '$lib/types/resource';
+    import { recalculatePanesAndMenus } from '$lib/stores/passage-page.store';
+    import { PassagePageTabEnum } from '../data-fetchers';
 
     export let bookChapterSelectorPane: CupertinoPane;
     export let isShowing: boolean;
     export let filterByCurrentGuide: boolean;
     export let bookCodesToNames: Record<string, string> | undefined;
+    export let tab: PassagePageTabEnum;
 
     let currentBook: ApiBibleBook;
     let currentChapter: ApiBibleChapter | null = null;
@@ -111,11 +113,8 @@
             return;
         }
 
-        if (firstSelectedVerse && lastSelectedVerse) {
-            firstSelectedVerse = null;
-            lastSelectedVerse = null;
-            return;
-        }
+        firstSelectedVerse = null;
+        lastSelectedVerse = null;
     }
 
     function isVerseInSelectedRange(
@@ -158,6 +157,7 @@
     }
 
     function handleBack() {
+        scrollBehaviorSmooth = false;
         if (currentStep === steps.two) {
             currentStep = steps.one;
         } else if (currentStep === steps.three) {
@@ -193,7 +193,11 @@
         currentChapter = null;
         firstSelectedVerse = null;
         lastSelectedVerse = null;
-        closeAllPassagePageMenus();
+        if ($currentGuide) {
+            tab = PassagePageTabEnum.Guide;
+        }
+        recalculatePanesAndMenus(tab);
+        scrollBehaviorSmooth = false;
     }
 
     function formatBibleVerseRange(
@@ -238,6 +242,7 @@
         });
 
         bookChapterSelectorPane.on('onDidDismiss', function () {
+            scrollBehaviorSmooth = false;
             currentStep = steps.one;
             currentChapter = null;
             firstSelectedVerse = null;

--- a/src/routes/view-content/bible-menu/BookPassageSelectorPane.svelte
+++ b/src/routes/view-content/bible-menu/BookPassageSelectorPane.svelte
@@ -6,13 +6,13 @@
     import { passagesByBookAvailableForGuide } from '$lib/utils/data-handlers/resources/guides';
     import { bibleSectionToReference } from '$lib/utils/bible-section-helpers';
     import type { BibleSection } from '$lib/types/bible';
-    import { closeAllPassagePageMenus } from '$lib/stores/passage-page.store';
     import ChevronLeftIcon from '$lib/icons/ChevronLeftIcon.svelte';
     import { currentGuide } from '$lib/stores/parent-resource.store';
     import { PredeterminedPassageGuides, type ApiParentResource } from '$lib/types/resource';
     import type { BasePassagesByBook } from '$lib/types/passage';
     import { isOnline } from '$lib/stores/is-online.store';
     import { PassagePageTabEnum } from '../data-fetchers';
+    import { recalculatePanesAndMenus } from '$lib/stores/passage-page.store';
 
     export let bookPassageSelectorPane: CupertinoPane;
     export let isShowing: boolean;
@@ -37,8 +37,10 @@
         $selectedBibleSection = passage;
         currentStep = steps.one;
         isShowing = false;
-        tab = PassagePageTabEnum.Guide;
-        closeAllPassagePageMenus();
+        if ($currentGuide) {
+            tab = PassagePageTabEnum.Guide;
+        }
+        recalculatePanesAndMenus(tab);
     }
 
     $: availablePassagesPromise = fetchAvailablePassages($currentGuide, $isOnline);

--- a/src/routes/view-content/quick-share/QuickShare.svelte
+++ b/src/routes/view-content/quick-share/QuickShare.svelte
@@ -28,7 +28,7 @@
 
     <p class="mb-2">{$translate('page.quickShare.orScan.value')}</p>
 
-    <div class="mb-6 px-2">
+    <div class="mb-6 max-h-96 max-w-96 px-2">
         <svg
             use:qr={{
                 data: 'https://app.well.bible',


### PR DESCRIPTION
This improves small things around the app:
- Add a max size for the QR code so it works on desktop
- Clear the current guide when going home so the user can get back to a Bible-first mode
- Display single verse references more nicely `2:15` instead of `2:15-15`
- Allow resetting the verse selection when you select the last verse of the book first
- Reset instant scrolling in verse selector so it's less jarring (it was only instant during the first time you selected a verse)
- Fix bug where changing verse range from resources tab would result in blank screen (refactors and moves some logic around to fix)