### PR TITLE
switch from CDN to API for Bible books

### DIFF
--- a/src/lib/components/file-manager/SelectBookMenu.svelte
+++ b/src/lib/components/file-manager/SelectBookMenu.svelte
@@ -29,6 +29,7 @@
     const handleBookClick = async (bookCode: string | null) => {
         toggleMenu();
         $biblesModuleBook = await addFrontEndDataToBiblesModuleBook(
+            firstBible.id,
             await fetchFromCacheOrApi(...bookOfBibleEndpoint(firstBible.id, bookCode))
         );
         $biblesModuleBook.bibleId = firstBible.id;

--- a/src/lib/data-cache.ts
+++ b/src/lib/data-cache.ts
@@ -6,6 +6,7 @@ import { asyncUnorderedForEach } from './utils/async-array';
 import { MediaType } from './types/resource';
 import { chunk, removeFromArray } from './utils/array';
 import { log } from './logger';
+import { objectValues } from './utils/typesafe-standard-lib';
 
 // Because we need to download metadata alongside content but we don't know ahead of time what the size of the payload
 // will be, we're defaulting it to 768 bytes (3/4 of a KB). Most metadata sizes as of now seem to be between 0-1000
@@ -294,7 +295,7 @@ export async function cacheManyFromCdnWithProgress(
         });
 
         if (batchIds.length > 0) {
-            const isMetadata = idsToUrls[0]?.url.includes('metadata');
+            const isMetadata = objectValues(idsToUrls)[0]?.url.includes('metadata') ?? false;
 
             try {
                 await retryRequest(async () => {

--- a/src/lib/stores/file-manager.store.ts
+++ b/src/lib/stores/file-manager.store.ts
@@ -35,7 +35,6 @@ export const biblesModuleBook = writable<BiblesModuleBook>({
     textSize: 0,
     audioSize: 0,
     chapterCount: 0,
-    textUrl: '',
     isTextUrlCached: false,
     bibleId: null,
     audioUrls: {

--- a/src/lib/types/bible.ts
+++ b/src/lib/types/bible.ts
@@ -20,12 +20,12 @@ export interface BibleBookTextContent {
 }
 
 export interface BibleBookTextChapter {
-    number: string;
+    number: number;
     verses: BibleBookTextVerse[];
 }
 
 export interface BibleBookTextVerse {
-    number: string;
+    number: number;
     text: string;
 }
 
@@ -59,7 +59,7 @@ export interface BaseBibleBookContent {
 export type ApiBibleBookContent = BaseBibleBookContent;
 
 export interface BibleBookContentDetails extends BaseBibleBookContent {
-    textUrl: string;
+    bibleId: number;
     audioUrls: { chapters: FrontendAudioChapter[] } | null;
 }
 
@@ -70,9 +70,9 @@ export interface FrontendChapterAudioData {
 }
 
 export interface FrontendChapterContent {
-    number: string;
+    number: number;
     audioData: FrontendChapterAudioData | null;
-    versesText: { number: string; text: string }[];
+    versesText: { number: number; text: string }[];
 }
 
 export type ApiBibleChapter = {

--- a/src/lib/types/file-manager.ts
+++ b/src/lib/types/file-manager.ts
@@ -111,7 +111,6 @@ export interface BiblesModuleBook {
     textSize: number;
     audioSize: number;
     chapterCount: number;
-    textUrl: string;
     isTextUrlCached?: boolean;
     bibleId: number | null;
     audioUrls: {

--- a/src/routes/file-manager/+page.svelte
+++ b/src/routes/file-manager/+page.svelte
@@ -39,6 +39,7 @@
                 if ($selectedBookCode) {
                     const firstBible = $biblesModuleData[0] || { id: null };
                     $biblesModuleBook = await addFrontEndDataToBiblesModuleBook(
+                        firstBible.id,
                         await fetchFromCacheOrApi(...bookOfBibleEndpoint(firstBible.id, $selectedBookCode))
                     );
                     $biblesModuleBook.bibleId = firstBible.id;

--- a/src/routes/view-content/+page.svelte
+++ b/src/routes/view-content/+page.svelte
@@ -173,7 +173,7 @@
                 $selectedBibleSection,
                 bibleData?.biblesForTabs
                     .filter(({ id, bookMetadata }) => id !== selectedBibleId && bookMetadata !== null)
-                    .map(({ bookMetadata }) => bookMetadata) as BibleBookContentDetails[]
+                    .map(({ id, bookMetadata }) => ({ ...bookMetadata, bibleId: id })) as BibleBookContentDetails[]
             );
         }
     }

--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -119,9 +119,9 @@ registerRoute(
     'POST'
 );
 
-// content from the CDN or metadata/thumbnails/text content from the API
+// content from the CDN or metadata/thumbnails/text/Bible content from the API
 registerRoute(
-    /(https:\/\/cdn\.aquifer\.bible.*|(https:\/\/((qa|dev)\.)?api-bn\.aquifer\.bible|http:\/\/localhost:5257)\/resources\/\d+\/(content|metadata|thumbnail))/,
+    /(https:\/\/cdn\.aquifer\.bible.*|(https:\/\/((qa|dev)\.)?api-bn\.aquifer\.bible|http:\/\/localhost:5257)(\/resources\/\d+\/(content|metadata|thumbnail)|\/bibles\/\d+\/texts.*))/,
     new CacheFirst({
         cacheName: 'aquifer-cdn',
         plugins: [new CacheableCdnContentPlugin(), new RangeRequestsPlugin(), addApiKeyToAllRequestPlugin],


### PR DESCRIPTION
This switches from the old CDN-based approach of fetching books of the Bible to using the API.