### PR TITLE
refactor caching to central config

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -1,3 +1,5 @@
+// <reference path="lib/caching-config.js" />
+
 // See https://kit.svelte.dev/docs/types#app
 // for information about these interfaces
 declare global {
@@ -12,6 +14,7 @@ declare global {
 
     interface Window {
         __CONFIG: Record<string, string | number | boolean>;
+        __CACHING_CONFIG: typeof CACHING_CONFIG;
         webkitAudioContext: AudioContext;
         onResourceReferenceClick: ((contentId: number) => void) | undefined;
     }

--- a/src/lib/caching-config.js
+++ b/src/lib/caching-config.js
@@ -1,0 +1,1 @@
+../../static/js/caching-config.js

--- a/src/lib/components/file-manager/DeleteModal.svelte
+++ b/src/lib/components/file-manager/DeleteModal.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { removeFromCdnCache } from '$lib/data-cache';
+    import { removeFromContentCache } from '$lib/data-cache';
     import { _ as translate } from 'svelte-i18n';
     import { downloadData, biblesModuleBook } from '$lib/stores/file-manager.store';
 
@@ -12,7 +12,7 @@
 
     const deleteFiles = () => {
         $downloadData.urlsToDelete.forEach((url) => {
-            removeFromCdnCache(url);
+            removeFromContentCache(url);
         });
 
         if ($biblesModuleBook.audioUrls) {

--- a/src/lib/components/file-manager/FmModal.svelte
+++ b/src/lib/components/file-manager/FmModal.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { convertToReadableSize } from '$lib/utils/file-manager';
-    import { removeFromCdnCache, cacheManyFromCdnWithProgress, type AllItemsProgress } from '$lib/data-cache';
+    import { removeFromContentCache, cacheManyContentUrlsWithProgress, type AllItemsProgress } from '$lib/data-cache';
     import { _ as translate } from 'svelte-i18n';
     import { objectKeys, objectValues } from '$lib/utils/typesafe-standard-lib';
     import { downloadData } from '$lib/stores/file-manager.store';
@@ -11,10 +11,10 @@
     let totalSizeDownloaded = 0;
 
     const continueUpdateFiles = () => {
-        $downloadData.urlsToDelete.forEach(removeFromCdnCache);
+        $downloadData.urlsToDelete.forEach(removeFromContentCache);
 
         if ($downloadData.urlsToDownload.length > 0) {
-            cacheManyFromCdnWithProgress($downloadData.urlsToDownload, progressCallback);
+            cacheManyContentUrlsWithProgress($downloadData.urlsToDownload, progressCallback);
             downloadInProgress = true;
         } else {
             const modal = document.getElementById('file-manager-modal') as HTMLDialogElement;

--- a/src/lib/components/file-manager/ViewTable.svelte
+++ b/src/lib/components/file-manager/ViewTable.svelte
@@ -15,7 +15,7 @@
     import { convertToReadableSize } from '$lib/utils/file-manager';
     import type { ResourcesApiModule, BiblesModuleBook } from '$lib/types/file-manager';
     import { buildRowData } from '$lib/utils/file-manager';
-    import { METADATA_ONLY_FAKE_FILE_SIZE, apiUrl, cacheManyFromCdnWithProgress } from '$lib/data-cache';
+    import { METADATA_ONLY_FAKE_FILE_SIZE, apiUrl, cacheManyContentUrlsWithProgress } from '$lib/data-cache';
     import { currentLanguageInfo } from '$lib/stores/language.store';
     import { MediaType, ParentResourceType, PredeterminedPassageGuides } from '$lib/types/resource';
     import Image from '$lib/icons/Image.svelte';
@@ -84,7 +84,7 @@
                     };
                 }
             });
-        await cacheManyFromCdnWithProgress(urlsToCache);
+        await cacheManyContentUrlsWithProgress(urlsToCache);
     }
 
     function addAllUrlsCachedProperty(biblesModuleBook: BiblesModuleBook) {

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -23,6 +23,7 @@ const additionalProperties = {
 
 export const log = {
     exception: (error: Error | undefined) => {
+        console.error(error);
         if (
             error &&
             (error.message.includes('Failed to fetch') ||
@@ -30,10 +31,8 @@ export const log = {
                 error.message.includes('NetworkError when attempting to fetch'))
         ) {
             // Don't log network errors to app insights (since they can't be avoided)
-            console.error(error);
         } else if (!browserSupported) {
             // Don't log errors of unsupported browsers to app insights (since they can't be avoided)
-            console.error(error);
         } else if (error) {
             const { url, cacheBustVersion } =
                 'url' in error ? (error as WellFetchError) : { url: null, cacheBustVersion: null };

--- a/src/lib/utils/array.ts
+++ b/src/lib/utils/array.ts
@@ -41,11 +41,6 @@ export function chunk<T>(array: T[], chunkSize: number): T[][] {
     return result;
 }
 
-export function removeFromArray<T>(array: T[], value: T) {
-    const index = array.indexOf(value);
-    if (index > -1) array.splice(index, 1);
-}
-
 export function sortByKey<T>(items: T[], key: keyof T, direction: 'asc' | 'desc' = 'asc'): T[] {
     return items.sort((a, b) => {
         if (a[key] > b[key]) {

--- a/src/lib/utils/data-handlers/bible.ts
+++ b/src/lib/utils/data-handlers/bible.ts
@@ -4,10 +4,10 @@ import { audioFileTypeForBrowser } from '../browser';
 import {
     METADATA_ONLY_FAKE_FILE_SIZE,
     apiUrl,
-    cacheManyFromCdnWithProgress,
+    cacheManyContentUrlsWithProgress,
     fetchFromCacheOrApi,
     isCachedFromApi,
-    isCachedFromCdn,
+    isCachedAsContent,
 } from '$lib/data-cache';
 import { asyncEvery, asyncFilter, asyncSome } from '../async-array';
 import { range } from '../array';
@@ -79,7 +79,7 @@ export async function bibleChaptersByBookAvailable(online: boolean, preferredBib
         return await asyncSome(preferredBibleIds, async (bibleId) => {
             if (await isCachedFromApi(bookOfBibleEndpoint(bibleId, bookAndChapterInfo.code)[0])) {
                 const textUrl = bibleBookUrl(bibleId, bookAndChapterInfo.code);
-                return await isCachedFromCdn(textUrl);
+                return await isCachedAsContent(textUrl);
             }
             return false;
         });
@@ -99,7 +99,7 @@ export async function availableBibles(online: boolean) {
                 return await asyncSome(bibleBookandChapterInfo, async (bookAndChapterInfo) => {
                     if (await isCachedFromApi(bookOfBibleEndpoint(bible.id, bookAndChapterInfo.code)[0])) {
                         const textUrl = bibleBookUrl(bible.id, bookAndChapterInfo.code);
-                        return await isCachedFromCdn(textUrl);
+                        return await isCachedAsContent(textUrl);
                     }
                     return false;
                 });
@@ -159,7 +159,7 @@ export async function cacheBiblesForBibleSection(
             range(bibleSection.startChapter, bibleSection.endChapter)
         )
     );
-    await cacheManyFromCdnWithProgress(urls);
+    await cacheManyContentUrlsWithProgress(urls);
 }
 
 export async function cacheBibleMetadata(bibleIds: number[]) {
@@ -168,7 +168,7 @@ export async function cacheBibleMetadata(bibleIds: number[]) {
         size: METADATA_ONLY_FAKE_FILE_SIZE,
         mediaType: MediaType.Text,
     }));
-    await cacheManyFromCdnWithProgress(urls);
+    await cacheManyContentUrlsWithProgress(urls);
 }
 
 export async function bookDataForBibleTab(bibleSection: BibleSection, bibleId: number, isPreferredBible: boolean) {
@@ -195,7 +195,7 @@ export async function bookDataForBibleTab(bibleSection: BibleSection, bibleId: n
 async function isContentCachedForOffline(bibleSection: BibleSection, bookData: BibleBookContentDetails | null) {
     if (bookData) {
         const textUrl = bibleBookUrl(bookData.bibleId, bookData.bookCode);
-        const textCached = await isCachedFromCdn(textUrl);
+        const textCached = await isCachedAsContent(textUrl);
         if (textCached) {
             return true;
         }
@@ -205,7 +205,7 @@ async function isContentCachedForOffline(bibleSection: BibleSection, bookData: B
                 const chapterAudioUrl = bookData!.audioUrls?.chapters?.find(
                     (chapter) => chapter.number === String(chapterNumber)
                 )?.[audioFileTypeForBrowser()]?.url;
-                return !!chapterAudioUrl && (await isCachedFromCdn(chapterAudioUrl));
+                return !!chapterAudioUrl && (await isCachedAsContent(chapterAudioUrl));
             }
         );
         if (audioCached) {

--- a/src/lib/utils/file-manager.ts
+++ b/src/lib/utils/file-manager.ts
@@ -1,4 +1,4 @@
-import { METADATA_ONLY_FAKE_FILE_SIZE, isCachedFromCdn } from '$lib/data-cache';
+import { METADATA_ONLY_FAKE_FILE_SIZE, isCachedAsContent } from '$lib/data-cache';
 import { asyncUnorderedForEach } from './async-array';
 import { audioFileTypeForBrowser } from './browser';
 import type {
@@ -236,10 +236,10 @@ export const addFrontEndDataToBiblesModuleBook = async (
     }
 
     inputBiblesModuleBook.isTextUrlCached =
-        !!bibleId && (await isCachedFromCdn(bibleBookUrl(bibleId, inputBiblesModuleBook.bookCode)));
+        !!bibleId && (await isCachedAsContent(bibleBookUrl(bibleId, inputBiblesModuleBook.bookCode)));
 
     await asyncUnorderedForEach(inputBiblesModuleBook.audioUrls?.chapters ?? [], async (chapter) => {
-        chapter.isAudioUrlCached = await isCachedFromCdn(chapter[audioFileTypeForBrowser()].url);
+        chapter.isAudioUrlCached = await isCachedAsContent(chapter[audioFileTypeForBrowser()].url);
         chapter.selected = false;
         chapter.allUrlsCached = false;
         chapter.fiaResourceUrls = [];
@@ -252,7 +252,7 @@ export const addFrontEndDataToBiblesModuleBook = async (
 export const addFrontEndDataToResourcesMenuItems = async (inputResourcesApiModule: ResourcesApiModule) => {
     await asyncUnorderedForEach(inputResourcesApiModule.chapters, async (chapter) => {
         await asyncUnorderedForEach(chapter.contents, async (content) => {
-            content.isResourceUrlCached = await isCachedFromCdn(resourceContentApiFullUrl(content));
+            content.isResourceUrlCached = await isCachedAsContent(resourceContentApiFullUrl(content));
         });
     });
 

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -13,6 +13,7 @@ import { languages } from '$lib/stores/language.store';
 import { parentResources } from '$lib/stores/parent-resource.store';
 import { biblesEndpoint, languagesEndpoint, parentResourcesEndpoint } from '$lib/api-endpoints';
 import { bibles } from '$lib/stores/bibles.store';
+import '$lib/caching-config.js';
 
 export const ssr = false;
 

--- a/src/routes/view-content/guide-content/FiaContent.svelte
+++ b/src/routes/view-content/guide-content/FiaContent.svelte
@@ -5,7 +5,7 @@
     } from '$lib/components/AudioPlayer/audio-player-state';
     import ButtonCarousel from '$lib/components/ButtonCarousel.svelte';
     import FullPageSpinner from '$lib/components/FullPageSpinner.svelte';
-    import { fetchFromCacheOrCdn } from '$lib/data-cache';
+    import { fetchContentFromCacheOrNetwork } from '$lib/data-cache';
     import { log } from '$lib/logger';
     import { openGuideMenu } from '$lib/stores/passage-page.store';
     import {
@@ -173,7 +173,7 @@
         return filterBoolean(
             await asyncMap(allTextResourceContent, async (resourceContent) => {
                 try {
-                    const content = (await fetchFromCacheOrCdn(
+                    const content = (await fetchContentFromCacheOrNetwork(
                         resourceContentApiFullUrl(resourceContent)
                     )) as ResourceContentFiaText[];
                     return {

--- a/static/js/caching-config.js
+++ b/static/js/caching-config.js
@@ -1,0 +1,94 @@
+// eslint-disable-next-line
+// @ts-nocheck
+
+// This file contains caching-related config used by the service worker and the app itself
+// For this reason and due to some issues with using one file in both places, the file is symlinked
+// into src/lib.
+
+const API_PATH_FOR_METADATA = '/resources/:ID/metadata';
+const API_PATH_FOR_CONTENT = '/resources/:ID/content';
+const API_URLS = [
+    'https://api-bn.aquifer.bible',
+    'https://qa.api-bn.aquifer.bible',
+    'https://dev.api-bn.aquifer.bible',
+    'http://localhost:5257',
+];
+
+const API_PATHS_TO_CACHE_AS_CONTENT = [
+    API_PATH_FOR_CONTENT,
+    API_PATH_FOR_METADATA,
+    '/resources/:ID/thumbnail',
+    '/bibles/:ID/texts',
+];
+
+const API_PATHS_TO_SKIP_CACHING = ['/resources/batch/metadata', '/resources/batch/content/text'];
+
+const CDN_URLS = ['https://cdn.aquifer.bible'];
+
+const cdnUrlRegex = createRegexFromUrlsAndPaths(CDN_URLS);
+const apiUrlsToCacheAsContentRegex = createRegexFromUrlsAndPaths(API_URLS, API_PATHS_TO_CACHE_AS_CONTENT);
+
+const apiContentUrlRegex = createRegexFromUrlsAndPaths(API_URLS, [API_PATH_FOR_CONTENT]);
+const apiMetadataUrlRegex = createRegexFromUrlsAndPaths(API_URLS, [API_PATH_FOR_METADATA]);
+
+const CACHING_CONFIG = {
+    contentCacheKey: 'aquifer-cdn',
+    apiCacheKey: 'aquifer-api',
+    cdnUrlRegex,
+    apiUrlsToCacheAsContentRegex,
+    apiContentUrlRegex,
+    apiMetadataUrlRegex,
+    apiSkipCacheUrlRegex: createRegexFromUrlsAndPaths(API_URLS, API_PATHS_TO_SKIP_CACHING),
+    apiUrlRegex: createRegexFromUrlsAndPaths(API_URLS),
+
+    // these are meant for usage in the app to determine what a given URL is
+    urlGoesInContentCache,
+    isContentUrl,
+    isMetadataUrl,
+};
+
+/**
+ * @param {string} url
+ */
+function urlGoesInContentCache(url) {
+    return cdnUrlRegex.test(url) || apiUrlsToCacheAsContentRegex.test(url);
+}
+
+/**
+ * @param {string} url
+ */
+function isContentUrl(url) {
+    return apiContentUrlRegex.test(url);
+}
+
+/**
+ * @param {string} url
+ */
+function isMetadataUrl(url) {
+    return apiMetadataUrlRegex.test(url);
+}
+
+/**
+ * @param {string[]} urls - Array of URLs.
+ * @param {string[]} [paths=[]] - Array of paths.
+ * @returns {RegExp} - Regular expression created from URLs and paths.
+ */
+function createRegexFromUrlsAndPaths(urls, paths = []) {
+    const combined = urls
+        .map((url) => {
+            if (paths.length === 0) {
+                return url;
+            } else {
+                return paths.map((path) => url + path);
+            }
+        })
+        .flat();
+    const escapedUrls = combined.map((url) => url.replace(/[-/\\^$*?.()|[\]{}]/g, '\\$&').replace(':ID', '\\d+'));
+    return new RegExp(`^(${escapedUrls.join('|')}).*`);
+}
+
+if (typeof window !== 'undefined') {
+    // eslint-disable-next-line
+    // @ts-ignore
+    window.__CACHING_CONFIG = CACHING_CONFIG;
+}

--- a/static/js/workbox-plugins/cacheable-media-or-text-content-plugin.js
+++ b/static/js/workbox-plugins/cacheable-media-or-text-content-plugin.js
@@ -1,6 +1,6 @@
 // Caches a response if it's a 200 OR it's a 206 and either the requested Range is not set or it's set to 0- which means all content
 // eslint-disable-next-line
-class CacheableCdnContentPlugin {
+class CacheableMediaOrTextContentPlugin {
     /**
      * Function to determine whether to cache a response.
      * @param {Object} params

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -19,7 +19,7 @@ const config = {
         typescript: {
             config: (config) => ({
                 ...config,
-                include: [...config.include, '../static/js/workbox-plugins/*.js'],
+                include: [...config.include, '../static/js/caching-config.js', '../static/js/workbox-plugins/*.js'],
                 exclude: config.exclude.filter((e) => e !== '../src/service-worker.ts'),
             }),
         },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,6 +12,9 @@ export default defineConfig({
         'process.env.DEPLOY_ENV': JSON.stringify(process.env.DEPLOY_ENV),
         'process.env.PUBLIC_AQUIFER_API_KEY': JSON.stringify(process.env.PUBLIC_AQUIFER_API_KEY),
     },
+    resolve: {
+        preserveSymlinks: true,
+    },
     plugins: [sveltekit(), SvelteKitPWA(serviceWorkerPwaConfig)],
     test: {
         globals: true,


### PR DESCRIPTION
This is a large refactor of the caching logic and renamed references to CDN to better fit with how things currently work.

Before we had an API and a CDN cache and the divide was very explicit. However now that most content lives in the API (except for media) that distinction doesn't make sense. I've renamed it to API and Content caches to make it clear that any content is meant for the content cache (even if it comes from the API), and API holds the rest.

Along with making that distinction clearer this also moves all URL regex handling into one file that can be used in the service worker and the app to determine which cache a given URL belongs to.