### PR TITLE
add check for `caches` to browserSupported variable

### DIFF
--- a/src/lib/utils/browser.ts
+++ b/src/lib/utils/browser.ts
@@ -15,4 +15,4 @@ export function audioFileTypeForBrowser() {
     return isSafariOnMacOrIOS() ? AudioType.mp3 : AudioType.webm;
 }
 
-export const browserSupported = browser && 'serviceWorker' in navigator;
+export const browserSupported = browser && 'serviceWorker' in navigator && 'caches' in window;

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -37,16 +37,16 @@ export const load: LayoutLoad = async () => {
                 // a consistent set of resources.
                 window.location.reload();
             }
-        }
 
-        const [fetchedLanguages, fetchedParentResources, fetchedBibles] = await Promise.all([
-            fetchFromCacheOrApi(...languagesEndpoint()),
-            fetchFromCacheOrApi(...parentResourcesEndpoint()),
-            fetchFromCacheOrApi(...biblesEndpoint()),
-        ]);
-        languages.set(fetchedLanguages);
-        parentResources.set(fetchedParentResources);
-        bibles.set(fetchedBibles);
+            const [fetchedLanguages, fetchedParentResources, fetchedBibles] = await Promise.all([
+                fetchFromCacheOrApi(...languagesEndpoint()),
+                fetchFromCacheOrApi(...parentResourcesEndpoint()),
+                fetchFromCacheOrApi(...biblesEndpoint()),
+            ]);
+            languages.set(fetchedLanguages);
+            parentResources.set(fetchedParentResources);
+            bibles.set(fetchedBibles);
+        }
 
         await init(get(currentLanguageInfo)?.iso6393Code);
         await waitLocale();


### PR DESCRIPTION
Also skips making requests if the browser is not supported, since they'll fail anyway.