### PR TITLE
don't blow up when newly added parent resource is not cached yet

### DIFF
--- a/src/lib/types/resource.ts
+++ b/src/lib/types/resource.ts
@@ -54,7 +54,7 @@ export interface AssociatedResource {
 }
 
 export interface ApiParentResource {
-    enabled: boolean;
+    enabled?: boolean;
     shortName: string;
     displayName: string;
     resourceType: ParentResourceType;

--- a/src/lib/utils/data-handlers/resources/guides.ts
+++ b/src/lib/utils/data-handlers/resources/guides.ts
@@ -72,7 +72,10 @@ export async function parentResourcesForCurrentLanguage() {
         ...parentResourcesEndpoint(languageId)
     )) as ApiParentResource[];
     return allParentResources.filter(
-        (pr) => (!showOnlySrvResources || SrvResources.includes(pr.id)) && pr.enabled && pr.resourceCountForLanguage > 0
+        (pr) =>
+            (!showOnlySrvResources || SrvResources.includes(pr.id)) &&
+            pr.enabled !== false &&
+            pr.resourceCountForLanguage > 0
     );
 }
 

--- a/src/routes/view-content/library-resource-loader.ts
+++ b/src/routes/view-content/library-resource-loader.ts
@@ -8,7 +8,7 @@ import {
     type ResourceContentInfoWithMetadata,
     type ResourceContentMetadata,
 } from '$lib/types/resource';
-import { groupBy } from '$lib/utils/array';
+import { filterBooleanByKey, groupBy } from '$lib/utils/array';
 import { asyncMap } from '$lib/utils/async-array';
 import {
     sortByDisplayName,
@@ -80,15 +80,14 @@ export async function buildLibraryResourceGroupingsWithMetadata(allResources: Re
             }
         });
         return {
-            parentResource: parentResourceIdMap[parentResourceId]!,
+            parentResource: parentResourceIdMap[parentResourceId],
             resources: sortByDisplayName(resourcesWithMetadata),
         };
     });
-    groupings.sort((a, b) => {
+    return filterBooleanByKey(groupings, 'parentResource').sort((a, b) => {
         return (
             RESOURCE_TYPE_ORDER.indexOf(a.parentResource.resourceType) -
             RESOURCE_TYPE_ORDER.indexOf(b.parentResource.resourceType)
         );
     });
-    return groupings;
 }


### PR DESCRIPTION
When a new parent resource is added, the resources tab may pull in new items but the parent resource list is still cached. When this happens it breaks the page. By filtering out resource items that don't have matching cached parent resources, we avoid the problem.