### PR TITLE
Resources Only Fetch When isShowing = true

### DIFF
--- a/src/routes/view-content/bible-menu/BookChapterSelectorPane.svelte
+++ b/src/routes/view-content/bible-menu/BookChapterSelectorPane.svelte
@@ -250,7 +250,13 @@
             lastSelectedVerse = null;
         });
 
-        bookChapterSelectorPane.disableDrag();
+        try {
+            bookChapterSelectorPane.disableDrag();
+        } catch (error) {
+            // do nothing because disableDrag throws
+            // an error in the console on desktop only.
+            // the pane still works as expected
+        }
     });
 
     afterUpdate(() => {

--- a/src/routes/view-content/bible-menu/BookPassageSelectorPane.svelte
+++ b/src/routes/view-content/bible-menu/BookPassageSelectorPane.svelte
@@ -70,7 +70,13 @@
             },
         });
 
-        bookPassageSelectorPane.disableDrag();
+        try {
+            bookPassageSelectorPane.disableDrag();
+        } catch (error) {
+            // do nothing because disableDrag throws
+            // an error in the console on desktop only.
+            // the pane still works as expected
+        }
     });
 </script>
 

--- a/src/routes/view-content/library-resource-menu/LibraryResourceMenu.svelte
+++ b/src/routes/view-content/library-resource-menu/LibraryResourceMenu.svelte
@@ -43,7 +43,7 @@
     let flatResources: ResourceContentInfoWithMetadata[] = [];
     let mediaResources: ResourceContentInfoWithMetadata[] = [];
 
-    $: prepareResources(resources || []);
+    $: prepareResources(resources || [], isShowing);
 
     $: filteredResourceCount = filterItemsByKeyMatchingSearchQuery(flatResources, 'displayName', searchQuery).length;
     $: hasQuery = searchQuery != '';
@@ -118,7 +118,8 @@
         currentFullscreenResourceGrouping = resourceGrouping;
     }
 
-    async function prepareResources(resources: ResourceContentInfo[]) {
+    async function prepareResources(resources: ResourceContentInfo[], isShowing: boolean) {
+        if (!isShowing) return;
         isLoading = true;
 
         resourceGroupings = await buildLibraryResourceGroupingsWithMetadata(resources);


### PR DESCRIPTION
This pr also resolves a console error that Cupertino Pane throws on desktop browsers only.  