### PR TITLE
make user id handling more robust

### DIFF
--- a/src/lib/components/AudioPlayer/audio-player-state.ts
+++ b/src/lib/components/AudioPlayer/audio-player-state.ts
@@ -353,19 +353,21 @@ class _AudioClip {
     }
 
     destroy() {
-        this.audioElement.remove();
-        this.audioElement.pause();
+        if (this.audioElement) {
+            this.audioElement.remove();
+            this.audioElement.pause();
 
-        this.audioElement.src = '';
-        this.audioElement.load();
+            this.audioElement.src = '';
+            this.audioElement.load();
 
-        this.audioElement.removeEventListener('canplaythrough', this.callbacks.onload);
-        this.audioElement.removeEventListener('play', this.callbacks.onplay);
-        this.audioElement.removeEventListener('pause', this.callbacks.onpause);
-        this.audioElement.removeEventListener('ended', this.callbacks.onended);
+            this.audioElement.removeEventListener('canplaythrough', this.callbacks.onload);
+            this.audioElement.removeEventListener('play', this.callbacks.onplay);
+            this.audioElement.removeEventListener('pause', this.callbacks.onpause);
+            this.audioElement.removeEventListener('ended', this.callbacks.onended);
 
-        if (this.audioElement.parentNode) {
-            this.audioElement.parentNode.removeChild(this.audioElement);
+            if (this.audioElement.parentNode) {
+                this.audioElement.parentNode.removeChild(this.audioElement);
+            }
         }
 
         URL.revokeObjectURL(this.file.url);

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -7,7 +7,7 @@ import { currentLanguageInfo } from '$lib/stores/language.store';
 // eslint-disable-next-line
 // @ts-ignore
 import { registerSW } from 'virtual:pwa-register';
-import { appInsightsEnabled, appInsightsUser, log } from '$lib/logger';
+import { appInsightsEnabled, userInfo, log } from '$lib/logger';
 import { browserSupported } from '$lib/utils/browser';
 import { languages } from '$lib/stores/language.store';
 import { parentResources } from '$lib/stores/parent-resource.store';
@@ -21,8 +21,8 @@ export const ssr = false;
 async function injectAppInsightsUserIdIntoServiceWorker(retries = 0) {
     if (retries < 20) {
         const swRegistration = await navigator.serviceWorker.getRegistration();
-        if (swRegistration?.active && appInsightsUser.id) {
-            swRegistration.active.postMessage({ appInsightsUserId: appInsightsUser.id });
+        if (swRegistration?.active && userInfo.id) {
+            swRegistration.active.postMessage({ userId: userInfo.id });
         } else {
             setTimeout(() => injectAppInsightsUserIdIntoServiceWorker(retries + 1), 250);
         }

--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -95,8 +95,8 @@ const API_CACHE_DURATION_IN_HOURS = isQa || isDev ? 1 : 24;
 const addApiKeyToAllRequestPlugin = new AddApiKeyToAllRequestPlugin(apiKey);
 
 self.addEventListener('message', (event) => {
-    if (event.data?.appInsightsUserId) {
-        addApiKeyToAllRequestPlugin.appInsightsUserId = event.data.appInsightsUserId;
+    if (event.data?.userId) {
+        addApiKeyToAllRequestPlugin.userId = event.data.userId;
     }
 });
 

--- a/static/js/workbox-plugins/add-api-key-to-all-request-plugin.js
+++ b/static/js/workbox-plugins/add-api-key-to-all-request-plugin.js
@@ -8,10 +8,10 @@ class AddApiKeyToAllRequestPlugin {
     apikey;
 
     /**
-     * The user id from App Insights context.
+     * The user id from App Insights context or custom generated cookie.
      * @type {string|undefined}
      */
-    appInsightsUserId = undefined;
+    userId = undefined;
 
     /**
      * Creates an instance of AddApiKeyToAllRequestPlugin.
@@ -37,8 +37,8 @@ class AddApiKeyToAllRequestPlugin {
         modifiedHeaders.delete('X-Cache-Bust-Version');
         modifiedHeaders.append('bn-source', 'bible-well');
 
-        if (this.appInsightsUserId) {
-            modifiedHeaders.append('bn-user-id', this.appInsightsUserId);
+        if (this.userId) {
+            modifiedHeaders.append('bn-user-id', this.userId);
         }
 
         return new Request(urlObj.toString(), {


### PR DESCRIPTION
Adds a setTimeout so we wait longer before attempting to get the id from the App Insights context. Then it adds a fallback to a custom generated ID stored in a cookie to ensure we can track requests even when App Insights fails.