### PR TITLE
add support for Fia domains

### DIFF
--- a/src/lib/stores/feature-flags.store.ts
+++ b/src/lib/stores/feature-flags.store.ts
@@ -5,6 +5,7 @@ import { browser } from '$app/environment';
 const defaultConfig = {
     darkMode: false,
     forceRTLMode: false,
+    forceFiaMode: false,
 };
 
 type FeatureFlagConfig = typeof defaultConfig;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -19,6 +19,7 @@
     import { get } from 'svelte/store';
     import { browserSupported } from '$lib/utils/browser';
     import CommunityEditionModal from '$lib/components/CommunityEditionModal.svelte';
+    import DebugModal from '$lib/components/DebugModal.svelte';
 
     $: {
         document.dir = $currentLanguageDirection;
@@ -108,6 +109,10 @@
     on:unhandledrejection={onRejection}
     on:click={onInteraction}
 />
+
+{#if $page.url.hash === '#ff'}
+    <DebugModal />
+{/if}
 
 <CommunityEditionModal />
 

--- a/src/routes/view-content/[guideId]/[bibleSection]/quick-share/QuickShare.svelte
+++ b/src/routes/view-content/[guideId]/[bibleSection]/quick-share/QuickShare.svelte
@@ -23,8 +23,8 @@
 
     <a
         class="mb-6 ms-4 underline underline-offset-2"
-        href="https://app.well.bible"
-        data-app-insights-event-name="quick-share-link-clicked">app.well.bible</a
+        href={window.location.origin}
+        data-app-insights-event-name="quick-share-link-clicked">{window.location.hostname}</a
     >
 
     <p class="mb-2">{$translate('page.quickShare.orScan.value')}</p>
@@ -32,7 +32,7 @@
     <div class="mb-6 max-h-96 max-w-96 px-2">
         <svg
             use:qr={{
-                data: 'https://app.well.bible',
+                data: window.location.origin,
                 logo: '/bibleWellLogoWithText-568.png',
                 shape: 'square',
             }}
@@ -47,8 +47,8 @@
             {$translate('page.quickShare.stepTwo.value')}
             <a
                 class="underline underline-offset-2"
-                href="https://app.well.bible"
-                data-app-insights-event-name="quick-share-link-clicked">app.well.bible</a
+                href={window.location.origin}
+                data-app-insights-event-name="quick-share-link-clicked">{window.location.hostname}</a
             >
         </li>
         <li class="ms-4">{$translate('page.quickShare.stepThree.value')}</li>


### PR DESCRIPTION
When the site's domain includes `fia` we turn on the SRV-only flag by default.

You can test it by opening the debug modal, add `#ff` to the end of the URL then check `forceFiaMode` and refresh.