### PR TITLE
filter out Fia ASL videos from library resource filter menu

### DIFF
--- a/src/routes/view-content/[guideId]/[bibleSection]/library-resource-menu/LibraryResourceMenu.svelte
+++ b/src/routes/view-content/[guideId]/[bibleSection]/library-resource-menu/LibraryResourceMenu.svelte
@@ -281,7 +281,12 @@
             hideLoadMore = true;
         }
 
-        response = response.filter((rc) => rc.mediaType !== MediaType.Audio);
+        response = response.filter(
+            (rc) =>
+                rc.mediaType !== MediaType.Audio &&
+                // Fia ASL videos don't work from the parent resource search view
+                (rc.mediaType !== MediaType.Video || rc.parentResourceId !== ParentResourceId.FIA)
+        );
 
         if (loadMore) {
             resourceSearchResources = [...resourceSearchResources, ...response];


### PR DESCRIPTION
Trying to access a Fia ASL video from the library resource menu causes issues, so this filters them out.