### PR TITLE
Treat verse 0 as superscript.

### DIFF
--- a/src/lib/utils/bible-section-helpers.ts
+++ b/src/lib/utils/bible-section-helpers.ts
@@ -161,7 +161,7 @@ export function stringToBibleSection(sectionString: string): BibleSection {
     return {
         bookCode,
         startChapter,
-        startVerse,
+        startVerse: startVerse === 1 ? 0 : startVerse,
         endChapter,
         endVerse,
     };
@@ -183,14 +183,15 @@ export function bibleSectionsEqual(passage1: BibleSection, passage2: BibleSectio
 
 export function bibleSectionToReference(bibleSection: BibleSection, scriptDirection: DirectionCode | undefined) {
     let reference: string;
+    const startVerse = bibleSection.startVerse === 0 ? 1 : bibleSection.startVerse;
     if (bibleSection.startChapter === bibleSection.endChapter) {
-        if (bibleSection.startVerse === bibleSection.endVerse) {
-            reference = `${bibleSection.startChapter}:${bibleSection.startVerse}`;
+        if (startVerse === bibleSection.endVerse) {
+            reference = `${bibleSection.startChapter}:${startVerse}`;
         } else {
-            reference = `${bibleSection.startChapter}:${bibleSection.startVerse}-${bibleSection.endVerse}`;
+            reference = `${bibleSection.startChapter}:${startVerse}-${bibleSection.endVerse}`;
         }
     } else {
-        reference = `${bibleSection.startChapter}:${bibleSection.startVerse}-${bibleSection.endChapter}:${bibleSection.endVerse}`;
+        reference = `${bibleSection.startChapter}:${startVerse}-${bibleSection.endChapter}:${bibleSection.endVerse}`;
     }
     return handleRtlVerseReferences(reference, scriptDirection)!;
 }

--- a/src/routes/view-content/[guideId]/[bibleSection]/BibleViewer.svelte
+++ b/src/routes/view-content/[guideId]/[bibleSection]/BibleViewer.svelte
@@ -169,10 +169,12 @@ ${verseNumber}, ${wordIndex})" class="cursor-pointer ${
                 {@const splitText = getSplitTextForAlignment(chapterIndex, verseIndex)}
                 <div
                     id="{chapterIndex}-{verseIndex}"
-                    class="py-1"
+                    class={number === 0 ? 'py-1 italic' : 'py-1'}
                     dir={lookupLanguageInfoById(currentBible.languageId)?.scriptDirection}
                 >
-                    <span class="sup pe-1">{number}</span>
+                    {#if number !== 0}
+                        <span class="sup pe-1">{number}</span>
+                    {/if}
                     {#if splitText && alignmentModeEnabled}
                         <!-- this conditional makes sure that if when we select a word we don't need to rerender every single verse but only the relevant one -->
                         {#if selectedChapterIndex === chapterIndex && selectedVerseIndex === verseIndex}


### PR DESCRIPTION
Many Psalms have superscript data.  Right now the superscript is included in the verse 1 text for all Bibles.  We are moving toward extracting out the superscripts and considering them verse "0" which allows for better versification mappings between Bible translations.  It also will allow us to easily display the superscript differently.  This PR is backwards compatible if there is no verse 0 data for a Psalm (see first screenshot) but will render verse 0 as an italicized superscript if it is present (see second screenshot).  The verse picker still only shows verse 1 as the first verse in the Psalm.

Audio data for the superscript is still associated with verse 1.  Thus, if you choose only verse 1 it will render under the hood both verse 0 and verse 1 and display them both as verse 1, which is still correct for audio timings.

Hebrew alignments are not yet supported so this doesn't need to handle alignment word mappings.  If we do eventually add OT alignment data, it uses verse 0 for superscripts so this should be forwards compatible.

Note that if you do manually type verse 0 into the URL everything will still work correctly.

No superscript:
![image](https://github.com/user-attachments/assets/ada3f036-d942-4d36-b4d6-5059047ddb3f)

Superscript:
![image](https://github.com/user-attachments/assets/a1dfecf5-b754-4575-a804-0b50353eafa2)
